### PR TITLE
wip godot experiment

### DIFF
--- a/platforms/godot/.gitignore
+++ b/platforms/godot/.gitignore
@@ -1,0 +1,22 @@
+# Godot-specific
+.godot/
+*.import
+*.translation
+
+# Build artifacts
+bin/
+*.so
+*.dll
+*.dylib
+*.framework
+
+# Zig
+.zig-cache/
+zig-out/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/platforms/godot/PROJECT_STRUCTURE.md
+++ b/platforms/godot/PROJECT_STRUCTURE.md
@@ -1,0 +1,208 @@
+# Project Structure
+
+```
+godot/
+├── 📄 colyseus.gdextension          # GDExtension configuration (tells Godot about the extension)
+├── 📄 build.zig                      # Zig build configuration
+├── 📄 .gitignore                     # Git ignore patterns
+├── 📄 README.md                      # Full documentation
+├── 📄 QUICKSTART.md                  # Quick start guide
+├── 📄 example.gd                     # Example GDScript usage
+├── include/                          # Godot GDExtension headers
+│   ├── 📄 gdextension_interface.h   # Godot C interface
+│   └── 📄 extension_api.json        # Godot API definitions
+└── src/                              # C source code
+    ├── 📄 godot_colyseus.h           # Main header with declarations
+    ├── 📄 register_types.c           # Extension registration
+    ├── 📄 colyseus_client.c          # ColyseusClient implementation
+    └── 📄 colyseus_room.c            # ColyseusRoom implementation
+```
+
+## File Descriptions
+
+### Configuration Files
+
+- **`colyseus.gdextension`**: The main configuration file that Godot reads to load the extension. Specifies entry points and library paths for different platforms.
+
+- **`build.zig`**: Zig build script that compiles the C code and links against the Colyseus native library. Supports cross-compilation and multiple optimization levels.
+
+- **`build.zig.zon`**: Zig package manifest defining the project metadata and dependencies.
+
+### Documentation
+
+- **`README.md`**: Complete documentation including building, installation, API reference, and architecture.
+
+- **`QUICKSTART.md`**: Condensed quick start guide for getting up and running quickly.
+
+- **`PROJECT_STRUCTURE.md`**: This file! Explains the project structure.
+
+### Examples
+
+- **`example.gd`**: A complete working example showing how to use the extension in GDScript.
+
+### Source Code
+
+#### Main Header (`godot_colyseus.h`)
+Central header file that declares all the types and functions for the extension. Contains:
+- Forward declarations for ColyseusClient and ColyseusRoom
+- GDExtension interface globals
+- Function declarations for all exposed methods
+
+#### Registration (`register_types.c`)
+Entry point for the extension. Handles:
+- Initializing the GDExtension interface
+- Registering ColyseusClient and ColyseusRoom classes with Godot
+- Setting up signals for room events
+- Binding methods to their implementations
+
+#### ColyseusClient (`colyseus_client.c`)
+Wraps the C `colyseus_client_t` API. Provides:
+- Connection to Colyseus servers
+- Endpoint parsing (ws:// and wss://)
+- String conversion helpers (Godot String ↔ C string)
+
+#### ColyseusRoom (`colyseus_room.c`)
+Wraps the C `colyseus_room_t` API. Handles:
+- Sending/receiving messages
+- Room lifecycle (join/leave)
+- Property accessors (id, session_id, name)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│         Godot Engine (GDScript)         │
+│   var client = ColyseusClient.new()    │
+└─────────────────┬───────────────────────┘
+                  │ GDExtension C API
+                  │
+┌─────────────────▼───────────────────────┐
+│    Pure C Wrapper (this extension)      │
+│  - register_types.c (registration)      │
+│  - colyseus_client.c (client wrapper)   │
+│  - colyseus_room.c (room wrapper)       │
+│  - godot_colyseus.h (declarations)      │
+└─────────────────┬───────────────────────┘
+                  │ C API calls
+                  │
+┌─────────────────▼───────────────────────┐
+│       Colyseus Native SDK (C)           │
+│  - colyseus_client_t                    │
+│  - colyseus_room_t                      │
+│  - WebSocket, HTTP, JSON handling       │
+└─────────────────────────────────────────┘
+```
+
+## Build Process
+
+```
+1. Build Colyseus Native SDK
+   └─> Produces: libcolyseus.a (static library)
+
+2. Build GDExtension (this project)
+   ├─> Compiles: src/*.c
+   ├─> Links: libcolyseus.a + libcurl
+   └─> Produces: libcolyseus_godot.{platform}.{build_type}.{ext}
+       (e.g., libcolyseus_godot.macos.debug.dylib)
+```
+
+**No godot-cpp needed!** This extension uses the raw GDExtension C API directly.
+
+## Platform-Specific Outputs
+
+| Platform | Debug | Release |
+|----------|-------|---------|
+| **macOS** | `bin/libcolyseus_godot.macos.debug.dylib` | `bin/libcolyseus_godot.macos.release.dylib` |
+| **Linux** | `bin/libcolyseus_godot.linux.x86_64.debug.so` | `bin/libcolyseus_godot.linux.x86_64.release.so` |
+| **Windows** | `bin/libcolyseus_godot.windows.x86_64.debug.dll` | `bin/libcolyseus_godot.windows.x86_64.release.dll` |
+
+## Key Design Decisions
+
+### 1. Pure C Implementation
+
+**Why C instead of C++?**
+- No dependency on godot-cpp (which is large and C++)
+- Direct use of GDExtension C API (native interface)
+- Faster compilation times
+- Smaller binary size
+- Better interoperability with the Colyseus C SDK
+
+**Trade-offs:**
+- More verbose than C++ (manual string handling, etc.)
+- No RAII or modern C++ conveniences
+- More manual memory management
+
+### 2. Zig Build System
+
+**Why Zig instead of SCons/CMake?**
+- Simple `zig build` command
+- Built-in cross-compilation
+- No external dependencies
+- Fast incremental builds
+- Consistent with main SDK build system
+
+**Trade-offs:**
+- Requires Zig to be installed
+- Less familiar to some developers
+
+### 3. Minimal API Surface
+
+This is a **barebones** implementation that exposes only the essential functionality:
+- Connection and room joining
+- Message sending/receiving
+- Basic property access
+
+Advanced features (state sync, schemas, etc.) are left for future implementation.
+
+## What's Implemented
+
+✅ Pure C implementation using GDExtension C API  
+✅ Zig build system with cross-compilation  
+✅ Basic class structure (ColyseusClient, ColyseusRoom)  
+✅ Connection to Colyseus server  
+✅ Send/receive messages  
+✅ Room lifecycle (join/leave)  
+✅ Godot signals for events  
+✅ String conversion helpers  
+
+## What's Not Yet Implemented
+
+⏳ Async operations with proper callbacks  
+⏳ State synchronization (delta patches)  
+⏳ Reconnection logic  
+⏳ Complete matchmaking API  
+⏳ Error handling for edge cases  
+⏳ Schema deserialization  
+⏳ Dictionary options parsing  
+
+## Code Organization Patterns
+
+### String Handling
+All string conversions go through helpers in `colyseus_client.c`:
+```c
+char* godot_string_to_utf8(GDExtensionConstStringPtr p_string);
+void godot_string_from_utf8(GDExtensionStringPtr r_dest, const char* p_utf8);
+```
+
+### Memory Management
+- Wrapper structs (ColyseusClient, ColyseusRoom) are malloc'd
+- Native SDK objects are owned by wrapper structs
+- Destructors free both wrapper and native objects
+
+### Method Binding
+All methods follow the GDExtension C API signature:
+```c
+void method_name(void* p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+```
+
+## Contributing
+
+Key areas for contribution:
+- Implementing async callbacks
+- State synchronization
+- Schema support
+- Dictionary options parsing
+- More comprehensive examples
+- Better error handling
+
+The pure C approach keeps the codebase simple and maintainable!

--- a/platforms/godot/QUICKSTART.md
+++ b/platforms/godot/QUICKSTART.md
@@ -1,0 +1,127 @@
+# Colyseus GDExtension - Quick Start
+
+## 🚀 3-Step Setup
+
+### 1. Build the Native SDK
+```bash
+cd ../..
+zig build
+```
+
+### 2. Build the Extension
+```bash
+cd platforms/godot
+zig build
+```
+
+### 3. Use in Your Godot Project
+
+Copy the `godot` folder to your Godot project, then create a script:
+
+```gdscript
+extends Node
+
+var client: ColyseusClient
+var room: ColyseusRoom
+
+func _ready():
+    # Connect to server
+    client = ColyseusClient.new()
+    client.connect_to("ws://localhost:2567")
+
+    # Join a room
+    room = client.join_or_create("my_room")
+
+    # Handle events
+    room.joined.connect(func(): print("Joined!"))
+    room.message_received.connect(func(data): print("Message: ", data))
+
+func send_greeting():
+    var data = "Hello".to_utf8_buffer()
+    room.send_message("greet", data)
+```
+
+## 🔧 Build Options
+
+```bash
+# Debug build (default)
+zig build
+
+# Release build (optimized)
+zig build -Doptimize=ReleaseFast
+
+# Cross-compile for Windows from macOS/Linux
+zig build -Dtarget=x86_64-windows
+
+# Cross-compile for Linux from macOS/Windows
+zig build -Dtarget=x86_64-linux
+```
+
+## 📚 API Overview
+
+### ColyseusClient
+```gdscript
+# Connection
+client.connect_to("ws://localhost:2567")
+
+# Join/Create rooms
+var room = client.join_or_create("room_name")
+var room = client.join("room_name")
+var room = client.join_by_id("room_id")
+var room = client.create_room("room_name")
+```
+
+### ColyseusRoom
+```gdscript
+# Send messages
+room.send_message("type", data)
+room.send_message_int(123, data)
+
+# Leave room
+room.leave()
+
+# Signals
+room.joined.connect(on_joined)
+room.state_changed.connect(on_state_changed)
+room.message_received.connect(on_message)
+room.error.connect(on_error)
+room.left.connect(on_left)
+```
+
+## 🎮 Running the Example Server
+
+```bash
+cd ../../example-server
+npm install
+npm start
+```
+
+Now you can test the extension with the example server!
+
+## ⚠️ Troubleshooting
+
+### "colyseus library not found"
+Build the native SDK first: `cd ../.. && zig build`
+
+### "curl not found"
+- **macOS**: `brew install curl`
+- **Linux**: `sudo apt install libcurl4-openssl-dev`
+- **Windows**: Install from https://curl.se/windows/
+
+### Extension not loading in Godot
+1. Check that `colyseus.gdextension` is in the extension folder
+2. Ensure the `.so`/`.dll`/`.dylib` file is in the `bin/` directory
+3. Check Godot's Output tab for error messages
+4. Verify the library name matches your platform in `colyseus.gdextension`
+
+## 💡 Why This Is Different
+
+This GDExtension is:
+- **Pure C** - No C++ or godot-cpp dependency
+- **Zig-built** - Simple `zig build` with easy cross-compilation
+- **Lightweight** - Minimal overhead, direct GDExtension C API usage
+- **Fast** - C is fast, Zig builds are cached and parallel
+
+## 📖 Full Documentation
+
+See [README.md](README.md) for complete API reference and architecture details.

--- a/platforms/godot/README.md
+++ b/platforms/godot/README.md
@@ -1,0 +1,189 @@
+# Colyseus GDExtension for Godot 4.1+
+
+A lightweight GDExtension that wraps the Colyseus Native SDK for use in Godot Engine. Written in pure C for maximum performance and minimal dependencies.
+
+## 🏗️ Building
+
+### Prerequisites
+
+**Build the Colyseus Native SDK first**:
+```bash
+cd ../..
+zig build
+```
+
+### Build the Extension
+
+```bash
+cd platforms/godot
+zig build
+```
+
+That's it! The extension will be built and placed in the `bin/` directory.
+
+#### Build Options
+
+```bash
+# Debug build (default)
+zig build
+
+# Release build
+zig build -Doptimize=ReleaseFast
+
+# Cross-compile for other platforms
+zig build -Dtarget=x86_64-linux
+zig build -Dtarget=x86_64-windows
+zig build -Dtarget=aarch64-macos
+```
+
+## 📦 Installation
+
+1. Copy the entire `platforms/godot` folder to your Godot project
+2. Make sure the `bin/` folder contains the compiled library for your platform
+3. The extension will be automatically loaded by Godot
+
+## 🚀 Usage
+
+```gdscript
+extends Node
+
+var client: ColyseusClient
+var room: ColyseusRoom
+
+func _ready():
+    # Create and connect client
+    client = ColyseusClient.new()
+    client.connect_to("ws://localhost:2567")
+    
+    # Join or create a room
+    room = client.join_or_create("my_room")
+    
+    # Connect signals
+    room.joined.connect(_on_room_joined)
+    room.state_changed.connect(_on_state_changed)
+    room.message_received.connect(_on_message_received)
+    room.error.connect(_on_room_error)
+    room.left.connect(_on_room_left)
+
+func _on_room_joined():
+    print("Joined room: ", room.get_id())
+    
+    # Send a message
+    var data = PackedByteArray()
+    data.append_array("Hello".to_utf8_buffer())
+    room.send_message("greeting", data)
+
+func _on_state_changed():
+    print("Room state changed")
+
+func _on_message_received(data: PackedByteArray):
+    print("Message received: ", data.get_string_from_utf8())
+
+func _on_room_error(code: int, message: String):
+    print("Room error: ", code, " - ", message)
+
+func _on_room_left(code: int, reason: String):
+    print("Left room: ", code, " - ", reason)
+```
+
+## 📋 API Reference
+
+### ColyseusClient
+
+#### Methods
+- `connect_to(endpoint: String)` - Connect to a Colyseus server
+- `join_or_create(room_name: String, options: Dictionary = {}) -> ColyseusRoom`
+- `create_room(room_name: String, options: Dictionary = {}) -> ColyseusRoom`
+- `join(room_name: String, options: Dictionary = {}) -> ColyseusRoom`
+- `join_by_id(room_id: String, options: Dictionary = {}) -> ColyseusRoom`
+- `get_endpoint() -> String`
+
+### ColyseusRoom
+
+#### Methods
+- `send_message(type: String, data: PackedByteArray)` - Send a string-typed message
+- `send_message_int(type: int, data: PackedByteArray)` - Send an integer-typed message
+- `leave(consented: bool = true)` - Leave the room
+- `get_id() -> String` - Get the room ID
+- `get_session_id() -> String` - Get the session ID
+- `get_name() -> String` - Get the room name
+- `has_joined() -> bool` - Check if successfully joined
+
+#### Signals
+- `joined()` - Emitted when successfully joined the room
+- `state_changed()` - Emitted when room state changes
+- `message_received(data: PackedByteArray)` - Emitted when a message is received
+- `error(code: int, message: String)` - Emitted on error
+- `left(code: int, reason: String)` - Emitted when leaving the room
+
+## 🔧 Architecture
+
+This extension is built with:
+- **Pure C** - No C++ dependencies, direct use of GDExtension C API
+- **Zig Build System** - Simple, fast, and supports easy cross-compilation
+- **Minimal Dependencies** - Only depends on the Colyseus Native SDK and libcurl
+
+```
+┌─────────────────────────────────────────┐
+│         Godot Engine (GDScript)         │
+│   var client = ColyseusClient.new()    │
+└─────────────────┬───────────────────────┘
+                  │ GDExtension C API
+                  │
+┌─────────────────▼───────────────────────┐
+│      Pure C Wrapper (this extension)    │
+│  - register_types.c                     │
+│  - colyseus_client.c                    │
+│  - colyseus_room.c                      │
+└─────────────────┬───────────────────────┘
+                  │ C API calls
+                  │
+┌─────────────────▼───────────────────────┐
+│       Colyseus Native SDK (C)           │
+│  - colyseus_client_t                    │
+│  - colyseus_room_t                      │
+│  - WebSocket, HTTP, JSON handling       │
+└─────────────────────────────────────────┘
+```
+
+## 🎯 Design Choices
+
+### Why C instead of C++?
+
+1. **Lighter** - No need for the large godot-cpp dependency
+2. **Simpler** - Direct use of GDExtension C API
+3. **Faster builds** - C compiles faster than C++
+4. **Smaller binaries** - No C++ standard library overhead
+5. **Better interop** - Native C API matches the Colyseus SDK
+
+### Why Zig for building?
+
+1. **Simple** - Just `zig build` with no external dependencies
+2. **Cross-compilation** - Easy to build for any platform
+3. **Fast** - Built-in caching and parallel compilation
+4. **No build tool dependencies** - Zig includes everything
+5. **Consistent** - Same build system as the main Colyseus SDK
+
+## ⚠️ Status
+
+This is a barebones implementation providing the foundation for Colyseus integration. 
+
+**Working:**
+- ✅ Basic class structure  
+- ✅ Connection to Colyseus server  
+- ✅ Send/receive messages  
+- ✅ Room lifecycle (join/leave)  
+- ✅ Godot signals for events  
+- ✅ Pure C implementation
+- ✅ Zig build system
+
+**Not Yet Implemented:**
+- ⏳ Async operations with proper callbacks  
+- ⏳ State synchronization (delta patches)  
+- ⏳ Reconnection logic  
+- ⏳ Complete matchmaking API  
+- ⏳ Schema deserialization  
+
+## 📝 License
+
+See LICENSE file in the root directory.

--- a/platforms/godot/build.zig
+++ b/platforms/godot/build.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Get target information
+    const os_tag = target.result.os.tag;
+    const arch = target.result.cpu.arch;
+
+    const os_str = switch (os_tag) {
+        .linux => "linux",
+        .macos => "macos",
+        .windows => "windows",
+        else => "unknown",
+    };
+
+    const arch_str = switch (arch) {
+        .x86_64 => "x86_64",
+        .aarch64 => "arm64",
+        else => "unknown",
+    };
+
+    const build_type = if (optimize == .Debug) "debug" else "release";
+
+    // Build library name based on platform
+    const lib_name = if (os_tag == .macos)
+        b.fmt("colyseus_godot.{s}.{s}", .{ os_str, build_type })
+    else
+        b.fmt("colyseus_godot.{s}.{s}.{s}", .{ os_str, arch_str, build_type });
+
+    // Create module for the shared library
+    const lib_module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Create the shared library for the GDExtension
+    const lib = b.addLibrary(.{
+        .name = lib_name,
+        .root_module = lib_module,
+        .linkage = .dynamic,
+    });
+
+    // Add C source files
+    lib.addCSourceFiles(.{
+        .files = &.{
+            "src/register_types.c",
+            "src/colyseus_client.c",
+            "src/colyseus_room.c",
+            // wslay sources (needed because libcolyseus.a doesn't include them)
+            "../../third_party/wslay/lib/wslay_event.c",
+            "../../third_party/wslay/lib/wslay_frame.c",
+            "../../third_party/wslay/lib/wslay_net.c",
+            "../../third_party/wslay/lib/wslay_queue.c",
+        },
+        .flags = &.{
+            "-Wall",
+            "-Wextra",
+            "-Wno-unused-parameter",
+        },
+    });
+
+    // Add include paths
+    lib.addIncludePath(b.path("../../include"));
+    lib.addIncludePath(b.path("../../third_party/uthash/src"));
+    lib.addIncludePath(b.path("../../third_party/wslay/lib/includes"));
+    lib.addIncludePath(b.path("../../third_party/wslay/lib"));
+    lib.addIncludePath(b.path("include"));
+
+    // Link against the colyseus static library
+    lib.addObjectFile(b.path("../../zig-out/lib/libcolyseus.a"));
+
+    // Generate wslay version header
+    const wslay_version_h = b.addConfigHeader(.{
+        .style = .{ .cmake = b.path("../../third_party/wslay/lib/includes/wslay/wslayver.h.in") },
+        .include_path = "wslay/wslayver.h",
+    }, .{
+        .PACKAGE_VERSION = "1.1.1",
+    });
+    lib.addConfigHeader(wslay_version_h);
+
+    // Link against system libraries
+    lib.linkLibC();
+
+    // Link libraries that colyseus depends on
+    lib.linkSystemLibrary("curl");
+    lib.linkSystemLibrary("pthread");
+
+    // Install to bin directory
+    const install_step = b.addInstallArtifact(lib, .{
+        .dest_dir = .{ .override = .{ .custom = "bin" } },
+    });
+
+    b.getInstallStep().dependOn(&install_step.step);
+}

--- a/platforms/godot/colyseus.gdextension
+++ b/platforms/godot/colyseus.gdextension
@@ -1,0 +1,12 @@
+[configuration]
+entry_symbol = "colyseus_sdk_init"
+compatibility_minimum = "4.1"
+
+[libraries]
+macos.debug = "res://zig-out/bin/libcolyseus_godot.macos.debug.dylib"
+macos.release = "res://zig-out/bin/libcolyseus_godot.macos.release.dylib"
+windows.debug.x86_64 = "res://zig-out/bin/libcolyseus_godot.windows.x86_64.debug.dll"
+windows.release.x86_64 = "res://zig-out/bin/libcolyseus_godot.windows.x86_64.release.dll"
+linux.debug.x86_64 = "res://zig-out/bin/libcolyseus_godot.linux.x86_64.debug.so"
+linux.release.x86_64 = "res://zig-out/bin/libcolyseus_godot.linux.x86_64.release.so"
+

--- a/platforms/godot/example.gd
+++ b/platforms/godot/example.gd
@@ -1,0 +1,51 @@
+extends Node
+## Example script demonstrating Colyseus GDExtension usage
+
+var client: ColyseusClient
+var room: ColyseusRoom
+
+func _ready():
+	# Create and connect client
+	client = ColyseusClient.new()
+	client.connect_to("ws://localhost:2567")
+	
+	print("Connecting to: ", client.get_endpoint())
+	
+	# Join or create a room
+	room = client.join_or_create("my_room")
+	
+	# Connect signals
+	if room:
+		room.joined.connect(_on_room_joined)
+		room.state_changed.connect(_on_state_changed)
+		room.message_received.connect(_on_message_received)
+		room.error.connect(_on_room_error)
+		room.left.connect(_on_room_left)
+
+func _on_room_joined():
+	print("✓ Joined room: ", room.get_id())
+	print("  Session ID: ", room.get_session_id())
+	print("  Room name: ", room.get_name())
+	
+	# Send a message
+	var message = "Hello from Godot!".to_utf8_buffer()
+	room.send_message("greeting", message)
+
+func _on_state_changed():
+	print("↻ Room state changed")
+
+func _on_message_received(data: PackedByteArray):
+	var message = data.get_string_from_utf8()
+	print("✉ Message received: ", message)
+
+func _on_room_error(code: int, message: String):
+	printerr("✗ Room error [", code, "]: ", message)
+
+func _on_room_left(code: int, reason: String):
+	print("← Left room [", code, "]: ", reason)
+
+func _exit_tree():
+	# Clean up when node is removed
+	if room and room.has_joined():
+		room.leave()
+

--- a/platforms/godot/include/gdextension_interface.h
+++ b/platforms/godot/include/gdextension_interface.h
@@ -1,0 +1,3198 @@
+/**************************************************************************/
+/*  gdextension_interface.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+/* This is a C class header, you can copy it and use it directly in your own binders.
+ * Together with the JSON file, you should be able to generate any binder.
+ */
+
+#ifndef __cplusplus
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint32_t char32_t;
+typedef uint16_t char16_t;
+#else
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+#endif
+
+/* VARIANT TYPES */
+
+typedef enum {
+	GDEXTENSION_VARIANT_TYPE_NIL,
+
+	/*  atomic types */
+	GDEXTENSION_VARIANT_TYPE_BOOL,
+	GDEXTENSION_VARIANT_TYPE_INT,
+	GDEXTENSION_VARIANT_TYPE_FLOAT,
+	GDEXTENSION_VARIANT_TYPE_STRING,
+
+	/* math types */
+	GDEXTENSION_VARIANT_TYPE_VECTOR2,
+	GDEXTENSION_VARIANT_TYPE_VECTOR2I,
+	GDEXTENSION_VARIANT_TYPE_RECT2,
+	GDEXTENSION_VARIANT_TYPE_RECT2I,
+	GDEXTENSION_VARIANT_TYPE_VECTOR3,
+	GDEXTENSION_VARIANT_TYPE_VECTOR3I,
+	GDEXTENSION_VARIANT_TYPE_TRANSFORM2D,
+	GDEXTENSION_VARIANT_TYPE_VECTOR4,
+	GDEXTENSION_VARIANT_TYPE_VECTOR4I,
+	GDEXTENSION_VARIANT_TYPE_PLANE,
+	GDEXTENSION_VARIANT_TYPE_QUATERNION,
+	GDEXTENSION_VARIANT_TYPE_AABB,
+	GDEXTENSION_VARIANT_TYPE_BASIS,
+	GDEXTENSION_VARIANT_TYPE_TRANSFORM3D,
+	GDEXTENSION_VARIANT_TYPE_PROJECTION,
+
+	/* misc types */
+	GDEXTENSION_VARIANT_TYPE_COLOR,
+	GDEXTENSION_VARIANT_TYPE_STRING_NAME,
+	GDEXTENSION_VARIANT_TYPE_NODE_PATH,
+	GDEXTENSION_VARIANT_TYPE_RID,
+	GDEXTENSION_VARIANT_TYPE_OBJECT,
+	GDEXTENSION_VARIANT_TYPE_CALLABLE,
+	GDEXTENSION_VARIANT_TYPE_SIGNAL,
+	GDEXTENSION_VARIANT_TYPE_DICTIONARY,
+	GDEXTENSION_VARIANT_TYPE_ARRAY,
+
+	/* typed arrays */
+	GDEXTENSION_VARIANT_TYPE_PACKED_BYTE_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_INT32_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_INT64_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_FLOAT32_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_FLOAT64_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_STRING_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_VECTOR2_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_VECTOR3_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_COLOR_ARRAY,
+	GDEXTENSION_VARIANT_TYPE_PACKED_VECTOR4_ARRAY,
+
+	GDEXTENSION_VARIANT_TYPE_VARIANT_MAX
+} GDExtensionVariantType;
+
+typedef enum {
+	/* comparison */
+	GDEXTENSION_VARIANT_OP_EQUAL,
+	GDEXTENSION_VARIANT_OP_NOT_EQUAL,
+	GDEXTENSION_VARIANT_OP_LESS,
+	GDEXTENSION_VARIANT_OP_LESS_EQUAL,
+	GDEXTENSION_VARIANT_OP_GREATER,
+	GDEXTENSION_VARIANT_OP_GREATER_EQUAL,
+
+	/* mathematic */
+	GDEXTENSION_VARIANT_OP_ADD,
+	GDEXTENSION_VARIANT_OP_SUBTRACT,
+	GDEXTENSION_VARIANT_OP_MULTIPLY,
+	GDEXTENSION_VARIANT_OP_DIVIDE,
+	GDEXTENSION_VARIANT_OP_NEGATE,
+	GDEXTENSION_VARIANT_OP_POSITIVE,
+	GDEXTENSION_VARIANT_OP_MODULE,
+	GDEXTENSION_VARIANT_OP_POWER,
+
+	/* bitwise */
+	GDEXTENSION_VARIANT_OP_SHIFT_LEFT,
+	GDEXTENSION_VARIANT_OP_SHIFT_RIGHT,
+	GDEXTENSION_VARIANT_OP_BIT_AND,
+	GDEXTENSION_VARIANT_OP_BIT_OR,
+	GDEXTENSION_VARIANT_OP_BIT_XOR,
+	GDEXTENSION_VARIANT_OP_BIT_NEGATE,
+
+	/* logic */
+	GDEXTENSION_VARIANT_OP_AND,
+	GDEXTENSION_VARIANT_OP_OR,
+	GDEXTENSION_VARIANT_OP_XOR,
+	GDEXTENSION_VARIANT_OP_NOT,
+
+	/* containment */
+	GDEXTENSION_VARIANT_OP_IN,
+	GDEXTENSION_VARIANT_OP_MAX
+
+} GDExtensionVariantOperator;
+
+// In this API there are multiple functions which expect the caller to pass a pointer
+// on return value as parameter.
+// In order to make it clear if the caller should initialize the return value or not
+// we have two flavor of types:
+// - `GDExtensionXXXPtr` for pointer on an initialized value
+// - `GDExtensionUninitializedXXXPtr` for pointer on uninitialized value
+//
+// Notes:
+// - Not respecting those requirements can seems harmless, but will lead to unexpected
+//   segfault or memory leak (for instance with a specific compiler/OS, or when two
+//   native extensions start doing ptrcall on each other).
+// - Initialization must be done with the function pointer returned by `variant_get_ptr_constructor`,
+//   zero-initializing the variable should not be considered a valid initialization method here !
+// - Some types have no destructor (see `extension_api.json`'s `has_destructor` field), for
+//   them it is always safe to skip the constructor for the return value if you are in a hurry ;-)
+
+typedef void *GDExtensionVariantPtr;
+typedef const void *GDExtensionConstVariantPtr;
+typedef void *GDExtensionUninitializedVariantPtr;
+typedef void *GDExtensionStringNamePtr;
+typedef const void *GDExtensionConstStringNamePtr;
+typedef void *GDExtensionUninitializedStringNamePtr;
+typedef void *GDExtensionStringPtr;
+typedef const void *GDExtensionConstStringPtr;
+typedef void *GDExtensionUninitializedStringPtr;
+typedef void *GDExtensionObjectPtr;
+typedef const void *GDExtensionConstObjectPtr;
+typedef void *GDExtensionUninitializedObjectPtr;
+typedef void *GDExtensionTypePtr;
+typedef const void *GDExtensionConstTypePtr;
+typedef void *GDExtensionUninitializedTypePtr;
+typedef const void *GDExtensionMethodBindPtr;
+typedef int64_t GDExtensionInt;
+typedef uint8_t GDExtensionBool;
+typedef uint64_t GDObjectInstanceID;
+typedef void *GDExtensionRefPtr;
+typedef const void *GDExtensionConstRefPtr;
+
+/* VARIANT DATA I/O */
+
+typedef enum {
+	GDEXTENSION_CALL_OK,
+	GDEXTENSION_CALL_ERROR_INVALID_METHOD,
+	GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT, // Expected a different variant type.
+	GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS, // Expected lower number of arguments.
+	GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS, // Expected higher number of arguments.
+	GDEXTENSION_CALL_ERROR_INSTANCE_IS_NULL,
+	GDEXTENSION_CALL_ERROR_METHOD_NOT_CONST, // Used for const call.
+} GDExtensionCallErrorType;
+
+typedef struct {
+	GDExtensionCallErrorType error;
+	int32_t argument;
+	int32_t expected;
+} GDExtensionCallError;
+
+typedef void (*GDExtensionVariantFromTypeConstructorFunc)(GDExtensionUninitializedVariantPtr, GDExtensionTypePtr);
+typedef void (*GDExtensionTypeFromVariantConstructorFunc)(GDExtensionUninitializedTypePtr, GDExtensionVariantPtr);
+typedef void *(*GDExtensionVariantGetInternalPtrFunc)(GDExtensionVariantPtr);
+typedef void (*GDExtensionPtrOperatorEvaluator)(GDExtensionConstTypePtr p_left, GDExtensionConstTypePtr p_right, GDExtensionTypePtr r_result);
+typedef void (*GDExtensionPtrBuiltInMethod)(GDExtensionTypePtr p_base, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_return, int p_argument_count);
+typedef void (*GDExtensionPtrConstructor)(GDExtensionUninitializedTypePtr p_base, const GDExtensionConstTypePtr *p_args);
+typedef void (*GDExtensionPtrDestructor)(GDExtensionTypePtr p_base);
+typedef void (*GDExtensionPtrSetter)(GDExtensionTypePtr p_base, GDExtensionConstTypePtr p_value);
+typedef void (*GDExtensionPtrGetter)(GDExtensionConstTypePtr p_base, GDExtensionTypePtr r_value);
+typedef void (*GDExtensionPtrIndexedSetter)(GDExtensionTypePtr p_base, GDExtensionInt p_index, GDExtensionConstTypePtr p_value);
+typedef void (*GDExtensionPtrIndexedGetter)(GDExtensionConstTypePtr p_base, GDExtensionInt p_index, GDExtensionTypePtr r_value);
+typedef void (*GDExtensionPtrKeyedSetter)(GDExtensionTypePtr p_base, GDExtensionConstTypePtr p_key, GDExtensionConstTypePtr p_value);
+typedef void (*GDExtensionPtrKeyedGetter)(GDExtensionConstTypePtr p_base, GDExtensionConstTypePtr p_key, GDExtensionTypePtr r_value);
+typedef uint32_t (*GDExtensionPtrKeyedChecker)(GDExtensionConstVariantPtr p_base, GDExtensionConstVariantPtr p_key);
+typedef void (*GDExtensionPtrUtilityFunction)(GDExtensionTypePtr r_return, const GDExtensionConstTypePtr *p_args, int p_argument_count);
+
+typedef GDExtensionObjectPtr (*GDExtensionClassConstructor)();
+
+typedef void *(*GDExtensionInstanceBindingCreateCallback)(void *p_token, void *p_instance);
+typedef void (*GDExtensionInstanceBindingFreeCallback)(void *p_token, void *p_instance, void *p_binding);
+typedef GDExtensionBool (*GDExtensionInstanceBindingReferenceCallback)(void *p_token, void *p_binding, GDExtensionBool p_reference);
+
+typedef struct {
+	GDExtensionInstanceBindingCreateCallback create_callback;
+	GDExtensionInstanceBindingFreeCallback free_callback;
+	GDExtensionInstanceBindingReferenceCallback reference_callback;
+} GDExtensionInstanceBindingCallbacks;
+
+/* EXTENSION CLASSES */
+
+typedef void *GDExtensionClassInstancePtr;
+
+typedef GDExtensionBool (*GDExtensionClassSet)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value);
+typedef GDExtensionBool (*GDExtensionClassGet)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
+typedef uint64_t (*GDExtensionClassGetRID)(GDExtensionClassInstancePtr p_instance);
+
+typedef struct {
+	GDExtensionVariantType type;
+	GDExtensionStringNamePtr name;
+	GDExtensionStringNamePtr class_name;
+	uint32_t hint; // Bitfield of `PropertyHint` (defined in `extension_api.json`).
+	GDExtensionStringPtr hint_string;
+	uint32_t usage; // Bitfield of `PropertyUsageFlags` (defined in `extension_api.json`).
+} GDExtensionPropertyInfo;
+
+typedef struct {
+	GDExtensionStringNamePtr name;
+	GDExtensionPropertyInfo return_value;
+	uint32_t flags; // Bitfield of `GDExtensionClassMethodFlags`.
+	int32_t id;
+
+	/* Arguments: `default_arguments` is an array of size `argument_count`. */
+	uint32_t argument_count;
+	GDExtensionPropertyInfo *arguments;
+
+	/* Default arguments: `default_arguments` is an array of size `default_argument_count`. */
+	uint32_t default_argument_count;
+	GDExtensionVariantPtr *default_arguments;
+} GDExtensionMethodInfo;
+
+typedef const GDExtensionPropertyInfo *(*GDExtensionClassGetPropertyList)(GDExtensionClassInstancePtr p_instance, uint32_t *r_count);
+typedef void (*GDExtensionClassFreePropertyList)(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list);
+typedef void (*GDExtensionClassFreePropertyList2)(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t p_count);
+typedef GDExtensionBool (*GDExtensionClassPropertyCanRevert)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name);
+typedef GDExtensionBool (*GDExtensionClassPropertyGetRevert)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
+typedef GDExtensionBool (*GDExtensionClassValidateProperty)(GDExtensionClassInstancePtr p_instance, GDExtensionPropertyInfo *p_property);
+typedef void (*GDExtensionClassNotification)(GDExtensionClassInstancePtr p_instance, int32_t p_what); // Deprecated. Use GDExtensionClassNotification2 instead.
+typedef void (*GDExtensionClassNotification2)(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed);
+typedef void (*GDExtensionClassToString)(GDExtensionClassInstancePtr p_instance, GDExtensionBool *r_is_valid, GDExtensionStringPtr p_out);
+typedef void (*GDExtensionClassReference)(GDExtensionClassInstancePtr p_instance);
+typedef void (*GDExtensionClassUnreference)(GDExtensionClassInstancePtr p_instance);
+typedef void (*GDExtensionClassCallVirtual)(GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
+typedef GDExtensionObjectPtr (*GDExtensionClassCreateInstance)(void *p_class_userdata);
+typedef GDExtensionObjectPtr (*GDExtensionClassCreateInstance2)(void *p_class_userdata, GDExtensionBool p_notify_postinitialize);
+typedef void (*GDExtensionClassFreeInstance)(void *p_class_userdata, GDExtensionClassInstancePtr p_instance);
+typedef GDExtensionClassInstancePtr (*GDExtensionClassRecreateInstance)(void *p_class_userdata, GDExtensionObjectPtr p_object);
+typedef GDExtensionClassCallVirtual (*GDExtensionClassGetVirtual)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name);
+typedef GDExtensionClassCallVirtual (*GDExtensionClassGetVirtual2)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name, uint32_t p_hash);
+typedef void *(*GDExtensionClassGetVirtualCallData)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name);
+typedef void *(*GDExtensionClassGetVirtualCallData2)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name, uint32_t p_hash);
+typedef void (*GDExtensionClassCallVirtualWithData)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, void *p_virtual_call_userdata, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
+
+typedef struct {
+	GDExtensionBool is_virtual;
+	GDExtensionBool is_abstract;
+	GDExtensionClassSet set_func;
+	GDExtensionClassGet get_func;
+	GDExtensionClassGetPropertyList get_property_list_func;
+	GDExtensionClassFreePropertyList free_property_list_func;
+	GDExtensionClassPropertyCanRevert property_can_revert_func;
+	GDExtensionClassPropertyGetRevert property_get_revert_func;
+	GDExtensionClassNotification notification_func;
+	GDExtensionClassToString to_string_func;
+	GDExtensionClassReference reference_func;
+	GDExtensionClassUnreference unreference_func;
+	GDExtensionClassCreateInstance create_instance_func; // (Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract.
+	GDExtensionClassFreeInstance free_instance_func; // Destructor; mandatory.
+	GDExtensionClassGetVirtual get_virtual_func; // Queries a virtual function by name and returns a callback to invoke the requested virtual function.
+	GDExtensionClassGetRID get_rid_func;
+	void *class_userdata; // Per-class user data, later accessible in instance bindings.
+} GDExtensionClassCreationInfo; // Deprecated. Use GDExtensionClassCreationInfo4 instead.
+
+typedef struct {
+	GDExtensionBool is_virtual;
+	GDExtensionBool is_abstract;
+	GDExtensionBool is_exposed;
+	GDExtensionClassSet set_func;
+	GDExtensionClassGet get_func;
+	GDExtensionClassGetPropertyList get_property_list_func;
+	GDExtensionClassFreePropertyList free_property_list_func;
+	GDExtensionClassPropertyCanRevert property_can_revert_func;
+	GDExtensionClassPropertyGetRevert property_get_revert_func;
+	GDExtensionClassValidateProperty validate_property_func;
+	GDExtensionClassNotification2 notification_func;
+	GDExtensionClassToString to_string_func;
+	GDExtensionClassReference reference_func;
+	GDExtensionClassUnreference unreference_func;
+	GDExtensionClassCreateInstance create_instance_func; // (Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract.
+	GDExtensionClassFreeInstance free_instance_func; // Destructor; mandatory.
+	GDExtensionClassRecreateInstance recreate_instance_func;
+	// Queries a virtual function by name and returns a callback to invoke the requested virtual function.
+	GDExtensionClassGetVirtual get_virtual_func;
+	// Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that
+	// need or benefit from extra data when calling virtual functions.
+	// Returns user data that will be passed to `call_virtual_with_data_func`.
+	// Returning `NULL` from this function signals to Godot that the virtual function is not overridden.
+	// Data returned from this function should be managed by the extension and must be valid until the extension is deinitialized.
+	// You should supply either `get_virtual_func`, or `get_virtual_call_data_func` with `call_virtual_with_data_func`.
+	GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+	// Used to call virtual functions when `get_virtual_call_data_func` is not null.
+	GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
+	GDExtensionClassGetRID get_rid_func;
+	void *class_userdata; // Per-class user data, later accessible in instance bindings.
+} GDExtensionClassCreationInfo2; // Deprecated. Use GDExtensionClassCreationInfo4 instead.
+
+typedef struct {
+	GDExtensionBool is_virtual;
+	GDExtensionBool is_abstract;
+	GDExtensionBool is_exposed;
+	GDExtensionBool is_runtime;
+	GDExtensionClassSet set_func;
+	GDExtensionClassGet get_func;
+	GDExtensionClassGetPropertyList get_property_list_func;
+	GDExtensionClassFreePropertyList2 free_property_list_func;
+	GDExtensionClassPropertyCanRevert property_can_revert_func;
+	GDExtensionClassPropertyGetRevert property_get_revert_func;
+	GDExtensionClassValidateProperty validate_property_func;
+	GDExtensionClassNotification2 notification_func;
+	GDExtensionClassToString to_string_func;
+	GDExtensionClassReference reference_func;
+	GDExtensionClassUnreference unreference_func;
+	GDExtensionClassCreateInstance create_instance_func; // (Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract.
+	GDExtensionClassFreeInstance free_instance_func; // Destructor; mandatory.
+	GDExtensionClassRecreateInstance recreate_instance_func;
+	// Queries a virtual function by name and returns a callback to invoke the requested virtual function.
+	GDExtensionClassGetVirtual get_virtual_func;
+	// Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that
+	// need or benefit from extra data when calling virtual functions.
+	// Returns user data that will be passed to `call_virtual_with_data_func`.
+	// Returning `NULL` from this function signals to Godot that the virtual function is not overridden.
+	// Data returned from this function should be managed by the extension and must be valid until the extension is deinitialized.
+	// You should supply either `get_virtual_func`, or `get_virtual_call_data_func` with `call_virtual_with_data_func`.
+	GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+	// Used to call virtual functions when `get_virtual_call_data_func` is not null.
+	GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
+	GDExtensionClassGetRID get_rid_func;
+	void *class_userdata; // Per-class user data, later accessible in instance bindings.
+} GDExtensionClassCreationInfo3; // Deprecated. Use GDExtensionClassCreationInfo4 instead.
+
+typedef struct {
+	GDExtensionBool is_virtual;
+	GDExtensionBool is_abstract;
+	GDExtensionBool is_exposed;
+	GDExtensionBool is_runtime;
+	GDExtensionConstStringPtr icon_path;
+	GDExtensionClassSet set_func;
+	GDExtensionClassGet get_func;
+	GDExtensionClassGetPropertyList get_property_list_func;
+	GDExtensionClassFreePropertyList2 free_property_list_func;
+	GDExtensionClassPropertyCanRevert property_can_revert_func;
+	GDExtensionClassPropertyGetRevert property_get_revert_func;
+	GDExtensionClassValidateProperty validate_property_func;
+	GDExtensionClassNotification2 notification_func;
+	GDExtensionClassToString to_string_func;
+	GDExtensionClassReference reference_func;
+	GDExtensionClassUnreference unreference_func;
+	GDExtensionClassCreateInstance2 create_instance_func; // (Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract.
+	GDExtensionClassFreeInstance free_instance_func; // Destructor; mandatory.
+	GDExtensionClassRecreateInstance recreate_instance_func;
+	// Queries a virtual function by name and returns a callback to invoke the requested virtual function.
+	GDExtensionClassGetVirtual2 get_virtual_func;
+	// Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that
+	// need or benefit from extra data when calling virtual functions.
+	// Returns user data that will be passed to `call_virtual_with_data_func`.
+	// Returning `NULL` from this function signals to Godot that the virtual function is not overridden.
+	// Data returned from this function should be managed by the extension and must be valid until the extension is deinitialized.
+	// You should supply either `get_virtual_func`, or `get_virtual_call_data_func` with `call_virtual_with_data_func`.
+	GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
+	// Used to call virtual functions when `get_virtual_call_data_func` is not null.
+	GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
+	void *class_userdata; // Per-class user data, later accessible in instance bindings.
+} GDExtensionClassCreationInfo4;
+
+typedef GDExtensionClassCreationInfo4 GDExtensionClassCreationInfo5;
+
+typedef void *GDExtensionClassLibraryPtr;
+
+/* Passed a pointer to a PackedStringArray that should be filled with the classes that may be used by the GDExtension. */
+typedef void (*GDExtensionEditorGetClassesUsedCallback)(GDExtensionTypePtr p_packed_string_array);
+
+/* Method */
+
+typedef enum {
+	GDEXTENSION_METHOD_FLAG_NORMAL = 1,
+	GDEXTENSION_METHOD_FLAG_EDITOR = 2,
+	GDEXTENSION_METHOD_FLAG_CONST = 4,
+	GDEXTENSION_METHOD_FLAG_VIRTUAL = 8,
+	GDEXTENSION_METHOD_FLAG_VARARG = 16,
+	GDEXTENSION_METHOD_FLAG_STATIC = 32,
+	GDEXTENSION_METHOD_FLAGS_DEFAULT = GDEXTENSION_METHOD_FLAG_NORMAL,
+} GDExtensionClassMethodFlags;
+
+typedef enum {
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT8,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT16,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT32,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT64,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_UINT8,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_UINT16,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_UINT32,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_UINT64,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_REAL_IS_FLOAT,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_REAL_IS_DOUBLE,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_CHAR16,
+	GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_CHAR32,
+} GDExtensionClassMethodArgumentMetadata;
+
+typedef void (*GDExtensionClassMethodCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error);
+typedef void (*GDExtensionClassMethodValidatedCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionVariantPtr r_return);
+typedef void (*GDExtensionClassMethodPtrCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
+
+typedef struct {
+	GDExtensionStringNamePtr name;
+	void *method_userdata;
+	GDExtensionClassMethodCall call_func;
+	GDExtensionClassMethodPtrCall ptrcall_func;
+	uint32_t method_flags; // Bitfield of `GDExtensionClassMethodFlags`.
+
+	/* If `has_return_value` is false, `return_value_info` and `return_value_metadata` are ignored.
+	 *
+	 * @todo Consider dropping `has_return_value` and making the other two properties match `GDExtensionMethodInfo` and `GDExtensionClassVirtualMethod` for consistency in future version of this struct.
+	 */
+	GDExtensionBool has_return_value;
+	GDExtensionPropertyInfo *return_value_info;
+	GDExtensionClassMethodArgumentMetadata return_value_metadata;
+
+	/* Arguments: `arguments_info` and `arguments_metadata` are array of size `argument_count`.
+	 * Name and hint information for the argument can be omitted in release builds. Class name should always be present if it applies.
+	 *
+	 * @todo Consider renaming `arguments_info` to `arguments` for consistency in future version of this struct.
+	 */
+	uint32_t argument_count;
+	GDExtensionPropertyInfo *arguments_info;
+	GDExtensionClassMethodArgumentMetadata *arguments_metadata;
+
+	/* Default arguments: `default_arguments` is an array of size `default_argument_count`. */
+	uint32_t default_argument_count;
+	GDExtensionVariantPtr *default_arguments;
+} GDExtensionClassMethodInfo;
+
+typedef struct {
+	GDExtensionStringNamePtr name;
+	uint32_t method_flags; // Bitfield of `GDExtensionClassMethodFlags`.
+
+	GDExtensionPropertyInfo return_value;
+	GDExtensionClassMethodArgumentMetadata return_value_metadata;
+
+	uint32_t argument_count;
+	GDExtensionPropertyInfo *arguments;
+	GDExtensionClassMethodArgumentMetadata *arguments_metadata;
+} GDExtensionClassVirtualMethodInfo;
+
+typedef void (*GDExtensionCallableCustomCall)(void *callable_userdata, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error);
+typedef GDExtensionBool (*GDExtensionCallableCustomIsValid)(void *callable_userdata);
+typedef void (*GDExtensionCallableCustomFree)(void *callable_userdata);
+
+typedef uint32_t (*GDExtensionCallableCustomHash)(void *callable_userdata);
+typedef GDExtensionBool (*GDExtensionCallableCustomEqual)(void *callable_userdata_a, void *callable_userdata_b);
+typedef GDExtensionBool (*GDExtensionCallableCustomLessThan)(void *callable_userdata_a, void *callable_userdata_b);
+
+typedef void (*GDExtensionCallableCustomToString)(void *callable_userdata, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out);
+
+typedef GDExtensionInt (*GDExtensionCallableCustomGetArgumentCount)(void *callable_userdata, GDExtensionBool *r_is_valid);
+
+typedef struct {
+	/* Only `call_func` and `token` are strictly required, however, `object_id` should be passed if its not a static method.
+	 *
+	 * `token` should point to an address that uniquely identifies the GDExtension (for example, the
+	 * `GDExtensionClassLibraryPtr` passed to the entry symbol function.
+	 *
+	 * `hash_func`, `equal_func`, and `less_than_func` are optional. If not provided both `call_func` and
+	 * `callable_userdata` together are used as the identity of the callable for hashing and comparison purposes.
+	 *
+	 * The hash returned by `hash_func` is cached, `hash_func` will not be called more than once per callable.
+	 *
+	 * `is_valid_func` is necessary if the validity of the callable can change before destruction.
+	 *
+	 * `free_func` is necessary if `callable_userdata` needs to be cleaned up when the callable is freed.
+	 */
+	void *callable_userdata;
+	void *token;
+
+	GDObjectInstanceID object_id;
+
+	GDExtensionCallableCustomCall call_func;
+	GDExtensionCallableCustomIsValid is_valid_func;
+	GDExtensionCallableCustomFree free_func;
+
+	GDExtensionCallableCustomHash hash_func;
+	GDExtensionCallableCustomEqual equal_func;
+	GDExtensionCallableCustomLessThan less_than_func;
+
+	GDExtensionCallableCustomToString to_string_func;
+} GDExtensionCallableCustomInfo; // Deprecated. Use GDExtensionCallableCustomInfo2 instead.
+
+typedef struct {
+	/* Only `call_func` and `token` are strictly required, however, `object_id` should be passed if its not a static method.
+	 *
+	 * `token` should point to an address that uniquely identifies the GDExtension (for example, the
+	 * `GDExtensionClassLibraryPtr` passed to the entry symbol function.
+	 *
+	 * `hash_func`, `equal_func`, and `less_than_func` are optional. If not provided both `call_func` and
+	 * `callable_userdata` together are used as the identity of the callable for hashing and comparison purposes.
+	 *
+	 * The hash returned by `hash_func` is cached, `hash_func` will not be called more than once per callable.
+	 *
+	 * `is_valid_func` is necessary if the validity of the callable can change before destruction.
+	 *
+	 * `free_func` is necessary if `callable_userdata` needs to be cleaned up when the callable is freed.
+	 */
+	void *callable_userdata;
+	void *token;
+
+	GDObjectInstanceID object_id;
+
+	GDExtensionCallableCustomCall call_func;
+	GDExtensionCallableCustomIsValid is_valid_func;
+	GDExtensionCallableCustomFree free_func;
+
+	GDExtensionCallableCustomHash hash_func;
+	GDExtensionCallableCustomEqual equal_func;
+	GDExtensionCallableCustomLessThan less_than_func;
+
+	GDExtensionCallableCustomToString to_string_func;
+
+	GDExtensionCallableCustomGetArgumentCount get_argument_count_func;
+} GDExtensionCallableCustomInfo2;
+
+/* SCRIPT INSTANCE EXTENSION */
+
+typedef void *GDExtensionScriptInstanceDataPtr; // Pointer to custom ScriptInstance native implementation.
+
+typedef GDExtensionBool (*GDExtensionScriptInstanceSet)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value);
+typedef GDExtensionBool (*GDExtensionScriptInstanceGet)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
+typedef const GDExtensionPropertyInfo *(*GDExtensionScriptInstanceGetPropertyList)(GDExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
+typedef void (*GDExtensionScriptInstanceFreePropertyList)(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo *p_list); // Deprecated. Use GDExtensionScriptInstanceFreePropertyList2 instead.
+typedef void (*GDExtensionScriptInstanceFreePropertyList2)(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t p_count);
+typedef GDExtensionBool (*GDExtensionScriptInstanceGetClassCategory)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_class_category);
+
+typedef GDExtensionVariantType (*GDExtensionScriptInstanceGetPropertyType)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid);
+typedef GDExtensionBool (*GDExtensionScriptInstanceValidateProperty)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_property);
+
+typedef GDExtensionBool (*GDExtensionScriptInstancePropertyCanRevert)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name);
+typedef GDExtensionBool (*GDExtensionScriptInstancePropertyGetRevert)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
+
+typedef GDExtensionObjectPtr (*GDExtensionScriptInstanceGetOwner)(GDExtensionScriptInstanceDataPtr p_instance);
+typedef void (*GDExtensionScriptInstancePropertyStateAdd)(GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value, void *p_userdata);
+typedef void (*GDExtensionScriptInstanceGetPropertyState)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionScriptInstancePropertyStateAdd p_add_func, void *p_userdata);
+
+typedef const GDExtensionMethodInfo *(*GDExtensionScriptInstanceGetMethodList)(GDExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
+typedef void (*GDExtensionScriptInstanceFreeMethodList)(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionMethodInfo *p_list); // Deprecated. Use GDExtensionScriptInstanceFreeMethodList2 instead.
+typedef void (*GDExtensionScriptInstanceFreeMethodList2)(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionMethodInfo *p_list, uint32_t p_count);
+
+typedef GDExtensionBool (*GDExtensionScriptInstanceHasMethod)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name);
+
+typedef GDExtensionInt (*GDExtensionScriptInstanceGetMethodArgumentCount)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid);
+
+typedef void (*GDExtensionScriptInstanceCall)(GDExtensionScriptInstanceDataPtr p_self, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error);
+typedef void (*GDExtensionScriptInstanceNotification)(GDExtensionScriptInstanceDataPtr p_instance, int32_t p_what); // Deprecated. Use GDExtensionScriptInstanceNotification2 instead.
+typedef void (*GDExtensionScriptInstanceNotification2)(GDExtensionScriptInstanceDataPtr p_instance, int32_t p_what, GDExtensionBool p_reversed);
+typedef void (*GDExtensionScriptInstanceToString)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out);
+
+typedef void (*GDExtensionScriptInstanceRefCountIncremented)(GDExtensionScriptInstanceDataPtr p_instance);
+typedef GDExtensionBool (*GDExtensionScriptInstanceRefCountDecremented)(GDExtensionScriptInstanceDataPtr p_instance);
+
+typedef GDExtensionObjectPtr (*GDExtensionScriptInstanceGetScript)(GDExtensionScriptInstanceDataPtr p_instance);
+typedef GDExtensionBool (*GDExtensionScriptInstanceIsPlaceholder)(GDExtensionScriptInstanceDataPtr p_instance);
+
+typedef void *GDExtensionScriptLanguagePtr;
+
+typedef GDExtensionScriptLanguagePtr (*GDExtensionScriptInstanceGetLanguage)(GDExtensionScriptInstanceDataPtr p_instance);
+
+typedef void (*GDExtensionScriptInstanceFree)(GDExtensionScriptInstanceDataPtr p_instance);
+
+typedef void *GDExtensionScriptInstancePtr; // Pointer to ScriptInstance.
+
+typedef struct {
+	GDExtensionScriptInstanceSet set_func;
+	GDExtensionScriptInstanceGet get_func;
+	GDExtensionScriptInstanceGetPropertyList get_property_list_func;
+	GDExtensionScriptInstanceFreePropertyList free_property_list_func;
+
+	GDExtensionScriptInstancePropertyCanRevert property_can_revert_func;
+	GDExtensionScriptInstancePropertyGetRevert property_get_revert_func;
+
+	GDExtensionScriptInstanceGetOwner get_owner_func;
+	GDExtensionScriptInstanceGetPropertyState get_property_state_func;
+
+	GDExtensionScriptInstanceGetMethodList get_method_list_func;
+	GDExtensionScriptInstanceFreeMethodList free_method_list_func;
+	GDExtensionScriptInstanceGetPropertyType get_property_type_func;
+
+	GDExtensionScriptInstanceHasMethod has_method_func;
+
+	GDExtensionScriptInstanceCall call_func;
+	GDExtensionScriptInstanceNotification notification_func;
+
+	GDExtensionScriptInstanceToString to_string_func;
+
+	GDExtensionScriptInstanceRefCountIncremented refcount_incremented_func;
+	GDExtensionScriptInstanceRefCountDecremented refcount_decremented_func;
+
+	GDExtensionScriptInstanceGetScript get_script_func;
+
+	GDExtensionScriptInstanceIsPlaceholder is_placeholder_func;
+
+	GDExtensionScriptInstanceSet set_fallback_func;
+	GDExtensionScriptInstanceGet get_fallback_func;
+
+	GDExtensionScriptInstanceGetLanguage get_language_func;
+
+	GDExtensionScriptInstanceFree free_func;
+
+} GDExtensionScriptInstanceInfo; // Deprecated. Use GDExtensionScriptInstanceInfo3 instead.
+
+typedef struct {
+	GDExtensionScriptInstanceSet set_func;
+	GDExtensionScriptInstanceGet get_func;
+	GDExtensionScriptInstanceGetPropertyList get_property_list_func;
+	GDExtensionScriptInstanceFreePropertyList free_property_list_func;
+	GDExtensionScriptInstanceGetClassCategory get_class_category_func; // Optional. Set to NULL for the default behavior.
+
+	GDExtensionScriptInstancePropertyCanRevert property_can_revert_func;
+	GDExtensionScriptInstancePropertyGetRevert property_get_revert_func;
+
+	GDExtensionScriptInstanceGetOwner get_owner_func;
+	GDExtensionScriptInstanceGetPropertyState get_property_state_func;
+
+	GDExtensionScriptInstanceGetMethodList get_method_list_func;
+	GDExtensionScriptInstanceFreeMethodList free_method_list_func;
+	GDExtensionScriptInstanceGetPropertyType get_property_type_func;
+	GDExtensionScriptInstanceValidateProperty validate_property_func;
+
+	GDExtensionScriptInstanceHasMethod has_method_func;
+
+	GDExtensionScriptInstanceCall call_func;
+	GDExtensionScriptInstanceNotification2 notification_func;
+
+	GDExtensionScriptInstanceToString to_string_func;
+
+	GDExtensionScriptInstanceRefCountIncremented refcount_incremented_func;
+	GDExtensionScriptInstanceRefCountDecremented refcount_decremented_func;
+
+	GDExtensionScriptInstanceGetScript get_script_func;
+
+	GDExtensionScriptInstanceIsPlaceholder is_placeholder_func;
+
+	GDExtensionScriptInstanceSet set_fallback_func;
+	GDExtensionScriptInstanceGet get_fallback_func;
+
+	GDExtensionScriptInstanceGetLanguage get_language_func;
+
+	GDExtensionScriptInstanceFree free_func;
+
+} GDExtensionScriptInstanceInfo2; // Deprecated. Use GDExtensionScriptInstanceInfo3 instead.
+
+typedef struct {
+	GDExtensionScriptInstanceSet set_func;
+	GDExtensionScriptInstanceGet get_func;
+	GDExtensionScriptInstanceGetPropertyList get_property_list_func;
+	GDExtensionScriptInstanceFreePropertyList2 free_property_list_func;
+	GDExtensionScriptInstanceGetClassCategory get_class_category_func; // Optional. Set to NULL for the default behavior.
+
+	GDExtensionScriptInstancePropertyCanRevert property_can_revert_func;
+	GDExtensionScriptInstancePropertyGetRevert property_get_revert_func;
+
+	GDExtensionScriptInstanceGetOwner get_owner_func;
+	GDExtensionScriptInstanceGetPropertyState get_property_state_func;
+
+	GDExtensionScriptInstanceGetMethodList get_method_list_func;
+	GDExtensionScriptInstanceFreeMethodList2 free_method_list_func;
+	GDExtensionScriptInstanceGetPropertyType get_property_type_func;
+	GDExtensionScriptInstanceValidateProperty validate_property_func;
+
+	GDExtensionScriptInstanceHasMethod has_method_func;
+
+	GDExtensionScriptInstanceGetMethodArgumentCount get_method_argument_count_func;
+
+	GDExtensionScriptInstanceCall call_func;
+	GDExtensionScriptInstanceNotification2 notification_func;
+
+	GDExtensionScriptInstanceToString to_string_func;
+
+	GDExtensionScriptInstanceRefCountIncremented refcount_incremented_func;
+	GDExtensionScriptInstanceRefCountDecremented refcount_decremented_func;
+
+	GDExtensionScriptInstanceGetScript get_script_func;
+
+	GDExtensionScriptInstanceIsPlaceholder is_placeholder_func;
+
+	GDExtensionScriptInstanceSet set_fallback_func;
+	GDExtensionScriptInstanceGet get_fallback_func;
+
+	GDExtensionScriptInstanceGetLanguage get_language_func;
+
+	GDExtensionScriptInstanceFree free_func;
+
+} GDExtensionScriptInstanceInfo3;
+
+typedef void (*GDExtensionWorkerThreadPoolGroupTask)(void *, uint32_t);
+typedef void (*GDExtensionWorkerThreadPoolTask)(void *);
+
+/* INITIALIZATION */
+
+typedef enum {
+	GDEXTENSION_INITIALIZATION_CORE,
+	GDEXTENSION_INITIALIZATION_SERVERS,
+	GDEXTENSION_INITIALIZATION_SCENE,
+	GDEXTENSION_INITIALIZATION_EDITOR,
+	GDEXTENSION_MAX_INITIALIZATION_LEVEL,
+} GDExtensionInitializationLevel;
+
+typedef void (*GDExtensionInitializeCallback)(void *p_userdata, GDExtensionInitializationLevel p_level);
+typedef void (*GDExtensionDeinitializeCallback)(void *p_userdata, GDExtensionInitializationLevel p_level);
+
+typedef struct {
+	/* Minimum initialization level required.
+	 * If Core or Servers, the extension needs editor or game restart to take effect */
+	GDExtensionInitializationLevel minimum_initialization_level;
+	/* Up to the user to supply when initializing */
+	void *userdata;
+	/* This function will be called multiple times for each initialization level. */
+	GDExtensionInitializeCallback initialize;
+	GDExtensionDeinitializeCallback deinitialize;
+} GDExtensionInitialization;
+
+typedef void (*GDExtensionInterfaceFunctionPtr)();
+typedef GDExtensionInterfaceFunctionPtr (*GDExtensionInterfaceGetProcAddress)(const char *p_function_name);
+
+/*
+ * Each GDExtension should define a C function that matches the signature of GDExtensionInitializationFunction,
+ * and export it so that it can be loaded via dlopen() or equivalent for the given platform.
+ *
+ * For example:
+ *
+ *   GDExtensionBool my_extension_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
+ *
+ * This function's name must be specified as the 'entry_symbol' in the .gdextension file.
+ *
+ * This makes it the entry point of the GDExtension and will be called on initialization.
+ *
+ * The GDExtension can then modify the r_initialization structure, setting the minimum initialization level,
+ * and providing pointers to functions that will be called at various stages of initialization/shutdown.
+ *
+ * The rest of the GDExtension's interface to Godot consists of function pointers that can be loaded
+ * by calling p_get_proc_address("...") with the name of the function.
+ *
+ * For example:
+ *
+ *   GDExtensionInterfaceGetGodotVersion get_godot_version = (GDExtensionInterfaceGetGodotVersion)p_get_proc_address("get_godot_version");
+ *
+ * (Note that snippet may cause "cast between incompatible function types" on some compilers, you can
+ * silence this by adding an intermediary `void*` cast.)
+ *
+ * You can then call it like a normal function:
+ *
+ *   GDExtensionGodotVersion godot_version;
+ *   get_godot_version(&godot_version);
+ *   printf("Godot v%d.%d.%d\n", godot_version.major, godot_version.minor, godot_version.patch);
+ *
+ * All of these interface functions are described below, together with the name that's used to load it,
+ * and the function pointer typedef that shows its signature.
+ */
+typedef GDExtensionBool (*GDExtensionInitializationFunction)(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
+
+/* INTERFACE */
+
+typedef struct {
+	uint32_t major;
+	uint32_t minor;
+	uint32_t patch;
+	const char *string;
+} GDExtensionGodotVersion;
+
+typedef struct {
+	uint32_t major;
+	uint32_t minor;
+	uint32_t patch;
+	uint32_t hex; // Full version encoded as hexadecimal with one byte (2 hex digits) per number (e.g. for "3.1.12" it would be 0x03010C)
+	const char *status; // (e.g. "stable", "beta", "rc1", "rc2")
+	const char *build; // (e.g. "custom_build")
+	const char *hash; // Full Git commit hash.
+	uint64_t timestamp; // Git commit date UNIX timestamp in seconds, or 0 if unavailable.
+	const char *string; // (e.g. "Godot v3.1.4.stable.official.mono")
+} GDExtensionGodotVersion2;
+
+/* Called when starting the main loop. */
+typedef void (*GDExtensionMainLoopStartupCallback)();
+
+/* Called when shutting down the main loop. */
+typedef void (*GDExtensionMainLoopShutdownCallback)();
+
+/* Called for every frame iteration of the main loop. */
+typedef void (*GDExtensionMainLoopFrameCallback)();
+
+typedef struct {
+	// Will be called after Godot is started and is fully initialized.
+	GDExtensionMainLoopStartupCallback startup_func;
+	// Will be called before Godot is shutdown when it is still fully initialized.
+	GDExtensionMainLoopShutdownCallback shutdown_func;
+	// Will be called for each process frame. This will run after all `_process()` methods on Node, and before `ScriptServer::frame()`.
+	// This is intended to be the equivalent of `ScriptLanguage::frame()` for GDExtension language bindings that don't use the script API.
+	GDExtensionMainLoopFrameCallback frame_func;
+} GDExtensionMainLoopCallbacks;
+
+/**
+ * @name get_godot_version
+ * @since 4.1
+ * @deprecated in Godot 4.5. Use `get_godot_version2` instead.
+ *
+ * Gets the Godot version that the GDExtension was loaded into.
+ *
+ * @param r_godot_version A pointer to the structure to write the version information into.
+ */
+typedef void (*GDExtensionInterfaceGetGodotVersion)(GDExtensionGodotVersion *r_godot_version);
+
+/**
+ * @name get_godot_version2
+ * @since 4.5
+ *
+ * Gets the Godot version that the GDExtension was loaded into.
+ *
+ * @param r_godot_version A pointer to the structure to write the version information into.
+ */
+typedef void (*GDExtensionInterfaceGetGodotVersion2)(GDExtensionGodotVersion2 *r_godot_version);
+
+/* INTERFACE: Memory */
+
+/**
+ * @name mem_alloc
+ * @since 4.1
+ *
+ * Allocates memory.
+ *
+ * @param p_bytes The amount of memory to allocate in bytes.
+ *
+ * @return A pointer to the allocated memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemAlloc)(size_t p_bytes);
+
+/**
+ * @name mem_realloc
+ * @since 4.1
+ *
+ * Reallocates memory.
+ *
+ * @param p_ptr A pointer to the previously allocated memory.
+ * @param p_bytes The number of bytes to resize the memory block to.
+ *
+ * @return A pointer to the allocated memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemRealloc)(void *p_ptr, size_t p_bytes);
+
+/**
+ * @name mem_free
+ * @since 4.1
+ *
+ * Frees memory.
+ *
+ * @param p_ptr A pointer to the previously allocated memory.
+ */
+typedef void (*GDExtensionInterfaceMemFree)(void *p_ptr);
+
+/* INTERFACE: Godot Core */
+
+/**
+ * @name print_error
+ * @since 4.1
+ *
+ * Logs an error to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code triggering the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintError)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_error_with_message
+ * @since 4.1
+ *
+ * Logs an error with a message to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code triggering the error.
+ * @param p_message The message to show along with the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintErrorWithMessage)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_warning
+ * @since 4.1
+ *
+ * Logs a warning to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code triggering the warning.
+ * @param p_function The function name where the warning occurred.
+ * @param p_file The file where the warning occurred.
+ * @param p_line The line where the warning occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintWarning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_warning_with_message
+ * @since 4.1
+ *
+ * Logs a warning with a message to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code triggering the warning.
+ * @param p_message The message to show along with the warning.
+ * @param p_function The function name where the warning occurred.
+ * @param p_file The file where the warning occurred.
+ * @param p_line The line where the warning occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintWarningWithMessage)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_script_error
+ * @since 4.1
+ *
+ * Logs a script error to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code triggering the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintScriptError)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_script_error_with_message
+ * @since 4.1
+ *
+ * Logs a script error with a message to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code triggering the error.
+ * @param p_message The message to show along with the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintScriptErrorWithMessage)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name get_native_struct_size
+ * @since 4.1
+ *
+ * Gets the size of a native struct (ex. ObjectID) in bytes.
+ *
+ * @param p_name A pointer to a StringName identifying the struct name.
+ *
+ * @return The size in bytes.
+ */
+typedef uint64_t (*GDExtensionInterfaceGetNativeStructSize)(GDExtensionConstStringNamePtr p_name);
+
+/* INTERFACE: Variant */
+
+/**
+ * @name variant_new_copy
+ * @since 4.1
+ *
+ * Copies one Variant into a another.
+ *
+ * @param r_dest A pointer to the destination Variant.
+ * @param p_src A pointer to the source Variant.
+ */
+typedef void (*GDExtensionInterfaceVariantNewCopy)(GDExtensionUninitializedVariantPtr r_dest, GDExtensionConstVariantPtr p_src);
+
+/**
+ * @name variant_new_nil
+ * @since 4.1
+ *
+ * Creates a new Variant containing nil.
+ *
+ * @param r_dest A pointer to the destination Variant.
+ */
+typedef void (*GDExtensionInterfaceVariantNewNil)(GDExtensionUninitializedVariantPtr r_dest);
+
+/**
+ * @name variant_destroy
+ * @since 4.1
+ *
+ * Destroys a Variant.
+ *
+ * @param p_self A pointer to the Variant to destroy.
+ */
+typedef void (*GDExtensionInterfaceVariantDestroy)(GDExtensionVariantPtr p_self);
+
+/**
+ * @name variant_call
+ * @since 4.1
+ *
+ * Calls a method on a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_method A pointer to a StringName identifying the method.
+ * @param p_args A pointer to a C array of Variant.
+ * @param p_argument_count The number of arguments.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_error A pointer the structure which will hold error information.
+ *
+ * @see Variant::callp()
+ */
+typedef void (*GDExtensionInterfaceVariantCall)(GDExtensionVariantPtr p_self, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
+
+/**
+ * @name variant_call_static
+ * @since 4.1
+ *
+ * Calls a static method on a Variant.
+ *
+ * @param p_type The variant type.
+ * @param p_method A pointer to a StringName identifying the method.
+ * @param p_args A pointer to a C array of Variant.
+ * @param p_argument_count The number of arguments.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_error A pointer the structure which will be updated with error information.
+ *
+ * @see Variant::call_static()
+ */
+typedef void (*GDExtensionInterfaceVariantCallStatic)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
+
+/**
+ * @name variant_evaluate
+ * @since 4.1
+ *
+ * Evaluate an operator on two Variants.
+ *
+ * @param p_op The operator to evaluate.
+ * @param p_a The first Variant.
+ * @param p_b The second Variant.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::evaluate()
+ */
+typedef void (*GDExtensionInterfaceVariantEvaluate)(GDExtensionVariantOperator p_op, GDExtensionConstVariantPtr p_a, GDExtensionConstVariantPtr p_b, GDExtensionUninitializedVariantPtr r_return, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set
+ * @since 4.1
+ *
+ * Sets a key on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::set()
+ */
+typedef void (*GDExtensionInterfaceVariantSet)(GDExtensionVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set_named
+ * @since 4.1
+ *
+ * Sets a named key on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a StringName representing the key.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::set_named()
+ */
+typedef void (*GDExtensionInterfaceVariantSetNamed)(GDExtensionVariantPtr p_self, GDExtensionConstStringNamePtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set_keyed
+ * @since 4.1
+ *
+ * Sets a keyed property on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::set_keyed()
+ */
+typedef void (*GDExtensionInterfaceVariantSetKeyed)(GDExtensionVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set_indexed
+ * @since 4.1
+ *
+ * Sets an index on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_index The index.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ * @param r_oob A pointer to a boolean which will be set to true if the index is out of bounds.
+ */
+typedef void (*GDExtensionInterfaceVariantSetIndexed)(GDExtensionVariantPtr p_self, GDExtensionInt p_index, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid, GDExtensionBool *r_oob);
+
+/**
+ * @name variant_get
+ * @since 4.1
+ *
+ * Gets the value of a key from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ */
+typedef void (*GDExtensionInterfaceVariantGet)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_named
+ * @since 4.1
+ *
+ * Gets the value of a named key from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a StringName representing the key.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ */
+typedef void (*GDExtensionInterfaceVariantGetNamed)(GDExtensionConstVariantPtr p_self, GDExtensionConstStringNamePtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_keyed
+ * @since 4.1
+ *
+ * Gets the value of a keyed property from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ */
+typedef void (*GDExtensionInterfaceVariantGetKeyed)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_indexed
+ * @since 4.1
+ *
+ * Gets the value of an index from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_index The index.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ * @param r_oob A pointer to a boolean which will be set to true if the index is out of bounds.
+ */
+typedef void (*GDExtensionInterfaceVariantGetIndexed)(GDExtensionConstVariantPtr p_self, GDExtensionInt p_index, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid, GDExtensionBool *r_oob);
+
+/**
+ * @name variant_iter_init
+ * @since 4.1
+ *
+ * Initializes an iterator over a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_iter A pointer to a Variant which will be assigned the iterator.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @return true if the operation is valid; otherwise false.
+ *
+ * @see Variant::iter_init()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantIterInit)(GDExtensionConstVariantPtr p_self, GDExtensionUninitializedVariantPtr r_iter, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_iter_next
+ * @since 4.1
+ *
+ * Gets the next value for an iterator over a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_iter A pointer to a Variant which will be assigned the iterator.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @return true if the operation is valid; otherwise false.
+ *
+ * @see Variant::iter_next()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantIterNext)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_iter, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_iter_get
+ * @since 4.1
+ *
+ * Gets the next value for an iterator over a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_iter A pointer to a Variant which will be assigned the iterator.
+ * @param r_ret A pointer to a Variant which will be assigned false if the operation is invalid.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::iter_get()
+ */
+typedef void (*GDExtensionInterfaceVariantIterGet)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_iter, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_hash
+ * @since 4.1
+ *
+ * Gets the hash of a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The hash value.
+ *
+ * @see Variant::hash()
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceVariantHash)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_recursive_hash
+ * @since 4.1
+ *
+ * Gets the recursive hash of a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_recursion_count The number of recursive loops so far.
+ *
+ * @return The hash value.
+ *
+ * @see Variant::recursive_hash()
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceVariantRecursiveHash)(GDExtensionConstVariantPtr p_self, GDExtensionInt p_recursion_count);
+
+/**
+ * @name variant_hash_compare
+ * @since 4.1
+ *
+ * Compares two Variants by their hash.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_other A pointer to the other Variant to compare it to.
+ *
+ * @return The hash value.
+ *
+ * @see Variant::hash_compare()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHashCompare)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_other);
+
+/**
+ * @name variant_booleanize
+ * @since 4.1
+ *
+ * Converts a Variant to a boolean.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The boolean value of the Variant.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantBooleanize)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_duplicate
+ * @since 4.1
+ *
+ * Duplicates a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_ret A pointer to a Variant to store the duplicated value.
+ * @param p_deep Whether or not to duplicate deeply (when supported by the Variant type).
+ */
+typedef void (*GDExtensionInterfaceVariantDuplicate)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_ret, GDExtensionBool p_deep);
+
+/**
+ * @name variant_stringify
+ * @since 4.1
+ *
+ * Converts a Variant to a string.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_ret A pointer to a String to store the resulting value.
+ */
+typedef void (*GDExtensionInterfaceVariantStringify)(GDExtensionConstVariantPtr p_self, GDExtensionStringPtr r_ret);
+
+/**
+ * @name variant_get_type
+ * @since 4.1
+ *
+ * Gets the type of a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The variant type.
+ */
+typedef GDExtensionVariantType (*GDExtensionInterfaceVariantGetType)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_has_method
+ * @since 4.1
+ *
+ * Checks if a Variant has the given method.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_method A pointer to a StringName with the method name.
+ *
+ * @return true if the variant has the given method; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHasMethod)(GDExtensionConstVariantPtr p_self, GDExtensionConstStringNamePtr p_method);
+
+/**
+ * @name variant_has_member
+ * @since 4.1
+ *
+ * Checks if a type of Variant has the given member.
+ *
+ * @param p_type The Variant type.
+ * @param p_member A pointer to a StringName with the member name.
+ *
+ * @return true if the variant has the given method; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHasMember)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
+
+/**
+ * @name variant_has_key
+ * @since 4.1
+ *
+ * Checks if a Variant has a key.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param r_valid A pointer to a boolean which will be set to false if the key doesn't exist.
+ *
+ * @return true if the key exists; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHasKey)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_object_instance_id
+ * @since 4.4
+ *
+ * Gets the object instance ID from a variant of type GDEXTENSION_VARIANT_TYPE_OBJECT.
+ *
+ * If the variant isn't of type GDEXTENSION_VARIANT_TYPE_OBJECT, then zero will be returned.
+ * The instance ID will be returned even if the object is no longer valid - use `object_get_instance_by_id()` to check if the object is still valid.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The instance ID for the contained object.
+ */
+typedef GDObjectInstanceID (*GDExtensionInterfaceVariantGetObjectInstanceId)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_get_type_name
+ * @since 4.1
+ *
+ * Gets the name of a Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param r_name A pointer to a String to store the Variant type name.
+ */
+typedef void (*GDExtensionInterfaceVariantGetTypeName)(GDExtensionVariantType p_type, GDExtensionUninitializedStringPtr r_name);
+
+/**
+ * @name variant_can_convert
+ * @since 4.1
+ *
+ * Checks if Variants can be converted from one type to another.
+ *
+ * @param p_from The Variant type to convert from.
+ * @param p_to The Variant type to convert to.
+ *
+ * @return true if the conversion is possible; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantCanConvert)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
+
+/**
+ * @name variant_can_convert_strict
+ * @since 4.1
+ *
+ * Checks if Variant can be converted from one type to another using stricter rules.
+ *
+ * @param p_from The Variant type to convert from.
+ * @param p_to The Variant type to convert to.
+ *
+ * @return true if the conversion is possible; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantCanConvertStrict)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
+
+/**
+ * @name get_variant_from_type_constructor
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can create a Variant of the given type from a raw value.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can create a Variant of the given type from a raw value.
+ */
+typedef GDExtensionVariantFromTypeConstructorFunc (*GDExtensionInterfaceGetVariantFromTypeConstructor)(GDExtensionVariantType p_type);
+
+/**
+ * @name get_variant_to_type_constructor
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can get the raw value from a Variant of the given type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can get the raw value from a Variant of the given type.
+ */
+typedef GDExtensionTypeFromVariantConstructorFunc (*GDExtensionInterfaceGetVariantToTypeConstructor)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_internal_getter
+ * @since 4.4
+ *
+ * Provides a function pointer for retrieving a pointer to a variant's internal value.
+ * Access to a variant's internal value can be used to modify it in-place, or to retrieve its value without the overhead of variant conversion functions.
+ * It is recommended to cache the getter for all variant types in a function table to avoid retrieval overhead upon use.
+ *
+ * @note Each function assumes the variant's type has already been determined and matches the function.
+ * Invoking the function with a variant of a mismatched type has undefined behavior, and may lead to a segmentation fault.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a type-specific function that returns a pointer to the internal value of a variant. Check the implementation of this function (gdextension_variant_get_ptr_internal_getter) for pointee type info of each variant type.
+ */
+typedef GDExtensionVariantGetInternalPtrFunc (*GDExtensionInterfaceGetVariantGetInternalPtrFunc)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_operator_evaluator
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can evaluate the given Variant operator on the given Variant types.
+ *
+ * @param p_operator The variant operator.
+ * @param p_type_a The type of the first Variant.
+ * @param p_type_b The type of the second Variant.
+ *
+ * @return A pointer to a function that can evaluate the given Variant operator on the given Variant types.
+ */
+typedef GDExtensionPtrOperatorEvaluator (*GDExtensionInterfaceVariantGetPtrOperatorEvaluator)(GDExtensionVariantOperator p_operator, GDExtensionVariantType p_type_a, GDExtensionVariantType p_type_b);
+
+/**
+ * @name variant_get_ptr_builtin_method
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can call a builtin method on a type of Variant.
+ *
+ * @param p_type The Variant type.
+ * @param p_method A pointer to a StringName with the method name.
+ * @param p_hash A hash representing the method signature.
+ *
+ * @return A pointer to a function that can call a builtin method on a type of Variant.
+ */
+typedef GDExtensionPtrBuiltInMethod (*GDExtensionInterfaceVariantGetPtrBuiltinMethod)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_method, GDExtensionInt p_hash);
+
+/**
+ * @name variant_get_ptr_constructor
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can call one of the constructors for a type of Variant.
+ *
+ * @param p_type The Variant type.
+ * @param p_constructor The index of the constructor.
+ *
+ * @return A pointer to a function that can call one of the constructors for a type of Variant.
+ */
+typedef GDExtensionPtrConstructor (*GDExtensionInterfaceVariantGetPtrConstructor)(GDExtensionVariantType p_type, int32_t p_constructor);
+
+/**
+ * @name variant_get_ptr_destructor
+ * @since 4.1
+ *
+ * Gets a pointer to a function than can call the destructor for a type of Variant.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function than can call the destructor for a type of Variant.
+ */
+typedef GDExtensionPtrDestructor (*GDExtensionInterfaceVariantGetPtrDestructor)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_construct
+ * @since 4.1
+ *
+ * Constructs a Variant of the given type, using the first constructor that matches the given arguments.
+ *
+ * @param p_type The Variant type.
+ * @param r_base A pointer to a Variant to store the constructed value.
+ * @param p_args A pointer to a C array of Variant pointers representing the arguments for the constructor.
+ * @param p_argument_count The number of arguments to pass to the constructor.
+ * @param r_error A pointer the structure which will be updated with error information.
+ */
+typedef void (*GDExtensionInterfaceVariantConstruct)(GDExtensionVariantType p_type, GDExtensionUninitializedVariantPtr r_base, const GDExtensionConstVariantPtr *p_args, int32_t p_argument_count, GDExtensionCallError *r_error);
+
+/**
+ * @name variant_get_ptr_setter
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can call a member's setter on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param p_member A pointer to a StringName with the member name.
+ *
+ * @return A pointer to a function that can call a member's setter on the given Variant type.
+ */
+typedef GDExtensionPtrSetter (*GDExtensionInterfaceVariantGetPtrSetter)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
+
+/**
+ * @name variant_get_ptr_getter
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can call a member's getter on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param p_member A pointer to a StringName with the member name.
+ *
+ * @return A pointer to a function that can call a member's getter on the given Variant type.
+ */
+typedef GDExtensionPtrGetter (*GDExtensionInterfaceVariantGetPtrGetter)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
+
+/**
+ * @name variant_get_ptr_indexed_setter
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can set an index on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can set an index on the given Variant type.
+ */
+typedef GDExtensionPtrIndexedSetter (*GDExtensionInterfaceVariantGetPtrIndexedSetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_indexed_getter
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can get an index on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can get an index on the given Variant type.
+ */
+typedef GDExtensionPtrIndexedGetter (*GDExtensionInterfaceVariantGetPtrIndexedGetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_keyed_setter
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can set a key on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can set a key on the given Variant type.
+ */
+typedef GDExtensionPtrKeyedSetter (*GDExtensionInterfaceVariantGetPtrKeyedSetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_keyed_getter
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can get a key on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can get a key on the given Variant type.
+ */
+typedef GDExtensionPtrKeyedGetter (*GDExtensionInterfaceVariantGetPtrKeyedGetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_keyed_checker
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can check a key on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can check a key on the given Variant type.
+ */
+typedef GDExtensionPtrKeyedChecker (*GDExtensionInterfaceVariantGetPtrKeyedChecker)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_constant_value
+ * @since 4.1
+ *
+ * Gets the value of a constant from the given Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param p_constant A pointer to a StringName with the constant name.
+ * @param r_ret A pointer to a Variant to store the value.
+ */
+typedef void (*GDExtensionInterfaceVariantGetConstantValue)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_constant, GDExtensionUninitializedVariantPtr r_ret);
+
+/**
+ * @name variant_get_ptr_utility_function
+ * @since 4.1
+ *
+ * Gets a pointer to a function that can call a Variant utility function.
+ *
+ * @param p_function A pointer to a StringName with the function name.
+ * @param p_hash A hash representing the function signature.
+ *
+ * @return A pointer to a function that can call a Variant utility function.
+ */
+typedef GDExtensionPtrUtilityFunction (*GDExtensionInterfaceVariantGetPtrUtilityFunction)(GDExtensionConstStringNamePtr p_function, GDExtensionInt p_hash);
+
+/* INTERFACE: String Utilities */
+
+/**
+ * @name string_new_with_latin1_chars
+ * @since 4.1
+ *
+ * Creates a String from a Latin-1 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a Latin-1 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithLatin1Chars)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents);
+
+/**
+ * @name string_new_with_utf8_chars
+ * @since 4.1
+ *
+ * Creates a String from a UTF-8 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-8 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf8Chars)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents);
+
+/**
+ * @name string_new_with_utf16_chars
+ * @since 4.1
+ *
+ * Creates a String from a UTF-16 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-16 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf16Chars)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents);
+
+/**
+ * @name string_new_with_utf32_chars
+ * @since 4.1
+ *
+ * Creates a String from a UTF-32 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-32 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf32Chars)(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents);
+
+/**
+ * @name string_new_with_wide_chars
+ * @since 4.1
+ *
+ * Creates a String from a wide C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a wide C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithWideChars)(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents);
+
+/**
+ * @name string_new_with_latin1_chars_and_len
+ * @since 4.1
+ *
+ * Creates a String from a Latin-1 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a Latin-1 encoded C string.
+ * @param p_size The number of characters (= number of bytes).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithLatin1CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_utf8_chars_and_len
+ * @since 4.1
+ * @deprecated in Godot 4.3. Use `string_new_with_utf8_chars_and_len2` instead.
+ *
+ * Creates a String from a UTF-8 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-8 encoded C string.
+ * @param p_size The number of bytes (not code units).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf8CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_utf8_chars_and_len2
+ * @since 4.3
+ *
+ * Creates a String from a UTF-8 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-8 encoded C string.
+ * @param p_size The number of bytes (not code units).
+ *
+ * @return Error code signifying if the operation successful.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringNewWithUtf8CharsAndLen2)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_utf16_chars_and_len
+ * @since 4.1
+ * @deprecated in Godot 4.3. Use `string_new_with_utf16_chars_and_len2` instead.
+ *
+ * Creates a String from a UTF-16 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-16 encoded C string.
+ * @param p_char_count The number of characters (not bytes).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf16CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count);
+
+/**
+ * @name string_new_with_utf16_chars_and_len2
+ * @since 4.3
+ *
+ * Creates a String from a UTF-16 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-16 encoded C string.
+ * @param p_char_count The number of characters (not bytes).
+ * @param p_default_little_endian If true, UTF-16 use little endian.
+ *
+ * @return Error code signifying if the operation successful.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringNewWithUtf16CharsAndLen2)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count, GDExtensionBool p_default_little_endian);
+
+/**
+ * @name string_new_with_utf32_chars_and_len
+ * @since 4.1
+ *
+ * Creates a String from a UTF-32 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-32 encoded C string.
+ * @param p_char_count The number of characters (not bytes).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf32CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents, GDExtensionInt p_char_count);
+
+/**
+ * @name string_new_with_wide_chars_and_len
+ * @since 4.1
+ *
+ * Creates a String from a wide C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a wide C string.
+ * @param p_char_count The number of characters (not bytes).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithWideCharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents, GDExtensionInt p_char_count);
+
+/**
+ * @name string_to_latin1_chars
+ * @since 4.1
+ *
+ * Converts a String to a Latin-1 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToLatin1Chars)(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_utf8_chars
+ * @since 4.1
+ *
+ * Converts a String to a UTF-8 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToUtf8Chars)(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_utf16_chars
+ * @since 4.1
+ *
+ * Converts a String to a UTF-16 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToUtf16Chars)(GDExtensionConstStringPtr p_self, char16_t *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_utf32_chars
+ * @since 4.1
+ *
+ * Converts a String to a UTF-32 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToUtf32Chars)(GDExtensionConstStringPtr p_self, char32_t *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_wide_chars
+ * @since 4.1
+ *
+ * Converts a String to a wide C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToWideChars)(GDExtensionConstStringPtr p_self, wchar_t *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to the character at the given index from a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_index The index.
+ *
+ * @return A pointer to the requested character.
+ */
+typedef char32_t *(*GDExtensionInterfaceStringOperatorIndex)(GDExtensionStringPtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name string_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to the character at the given index from a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_index The index.
+ *
+ * @return A const pointer to the requested character.
+ */
+typedef const char32_t *(*GDExtensionInterfaceStringOperatorIndexConst)(GDExtensionConstStringPtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name string_operator_plus_eq_string
+ * @since 4.1
+ *
+ * Appends another String to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to the other String to append.
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqString)(GDExtensionStringPtr p_self, GDExtensionConstStringPtr p_b);
+
+/**
+ * @name string_operator_plus_eq_char
+ * @since 4.1
+ *
+ * Appends a character to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to the character to append.
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqChar)(GDExtensionStringPtr p_self, char32_t p_b);
+
+/**
+ * @name string_operator_plus_eq_cstr
+ * @since 4.1
+ *
+ * Appends a Latin-1 encoded C string to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to a Latin-1 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqCstr)(GDExtensionStringPtr p_self, const char *p_b);
+
+/**
+ * @name string_operator_plus_eq_wcstr
+ * @since 4.1
+ *
+ * Appends a wide C string to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to a wide C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqWcstr)(GDExtensionStringPtr p_self, const wchar_t *p_b);
+
+/**
+ * @name string_operator_plus_eq_c32str
+ * @since 4.1
+ *
+ * Appends a UTF-32 encoded C string to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to a UTF-32 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqC32str)(GDExtensionStringPtr p_self, const char32_t *p_b);
+
+/**
+ * @name string_resize
+ * @since 4.2
+ *
+ * Resizes the underlying string data to the given number of characters.
+ *
+ * Space needs to be allocated for the null terminating character ('\0') which
+ * also must be added manually, in order for all string functions to work correctly.
+ *
+ * Warning: This is an error-prone operation - only use it if there's no other
+ * efficient way to accomplish your goal.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_resize The new length for the String.
+ *
+ * @return Error code signifying if the operation successful.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringResize)(GDExtensionStringPtr p_self, GDExtensionInt p_resize);
+
+/* INTERFACE: StringName Utilities */
+
+/**
+ * @name string_name_new_with_latin1_chars
+ * @since 4.2
+ *
+ * Creates a StringName from a Latin-1 encoded C string.
+ *
+ * If `p_is_static` is true, then:
+ * - The StringName will reuse the `p_contents` buffer instead of copying it.
+ *   You must guarantee that the buffer remains valid for the duration of the application (e.g. string literal).
+ * - You must not call a destructor for this StringName. Incrementing the initial reference once should achieve this.
+ *
+ * `p_is_static` is purely an optimization and can easily introduce undefined behavior if used wrong. In case of doubt, set it to false.
+ *
+ * @param r_dest A pointer to uninitialized storage, into which the newly created StringName is constructed.
+ * @param p_contents A pointer to a C string (null terminated and Latin-1 or ASCII encoded).
+ * @param p_is_static Whether the StringName reuses the buffer directly (see above).
+ */
+typedef void (*GDExtensionInterfaceStringNameNewWithLatin1Chars)(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents, GDExtensionBool p_is_static);
+
+/**
+ * @name string_name_new_with_utf8_chars
+ * @since 4.2
+ *
+ * Creates a StringName from a UTF-8 encoded C string.
+ *
+ * @param r_dest A pointer to uninitialized storage, into which the newly created StringName is constructed.
+ * @param p_contents A pointer to a C string (null terminated and UTF-8 encoded).
+ */
+typedef void (*GDExtensionInterfaceStringNameNewWithUtf8Chars)(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents);
+
+/**
+ * @name string_name_new_with_utf8_chars_and_len
+ * @since 4.2
+ *
+ * Creates a StringName from a UTF-8 encoded string with a given number of characters.
+ *
+ * @param r_dest A pointer to uninitialized storage, into which the newly created StringName is constructed.
+ * @param p_contents A pointer to a C string (null terminated and UTF-8 encoded).
+ * @param p_size The number of bytes (not UTF-8 code points).
+ */
+typedef void (*GDExtensionInterfaceStringNameNewWithUtf8CharsAndLen)(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/* INTERFACE: XMLParser Utilities */
+
+/**
+ * @name xml_parser_open_buffer
+ * @since 4.1
+ *
+ * Opens a raw XML buffer on an XMLParser instance.
+ *
+ * @param p_instance A pointer to an XMLParser object.
+ * @param p_buffer A pointer to the buffer.
+ * @param p_size The size of the buffer.
+ *
+ * @return A Godot error code (ex. OK, ERR_INVALID_DATA, etc).
+ *
+ * @see XMLParser::open_buffer()
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceXmlParserOpenBuffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_buffer, size_t p_size);
+
+/* INTERFACE: FileAccess Utilities */
+
+/**
+ * @name file_access_store_buffer
+ * @since 4.1
+ *
+ * Stores the given buffer using an instance of FileAccess.
+ *
+ * @param p_instance A pointer to a FileAccess object.
+ * @param p_src A pointer to the buffer.
+ * @param p_length The size of the buffer.
+ *
+ * @see FileAccess::store_buffer()
+ */
+typedef void (*GDExtensionInterfaceFileAccessStoreBuffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length);
+
+/**
+ * @name file_access_get_buffer
+ * @since 4.1
+ *
+ * Reads the next p_length bytes into the given buffer using an instance of FileAccess.
+ *
+ * @param p_instance A pointer to a FileAccess object.
+ * @param p_dst A pointer to the buffer to store the data.
+ * @param p_length The requested number of bytes to read.
+ *
+ * @return The actual number of bytes read (may be less than requested).
+ */
+typedef uint64_t (*GDExtensionInterfaceFileAccessGetBuffer)(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length);
+
+/* INTERFACE: Image Utilities */
+
+/**
+ * @name image_ptrw
+ * @since 4.3
+ *
+ * Returns writable pointer to internal Image buffer.
+ *
+ * @param p_instance A pointer to a Image object.
+ *
+ * @return Pointer to internal Image buffer.
+ *
+ * @see Image::ptrw()
+ */
+typedef uint8_t *(*GDExtensionInterfaceImagePtrw)(GDExtensionObjectPtr p_instance);
+
+/**
+ * @name image_ptr
+ * @since 4.3
+ *
+ * Returns read only pointer to internal Image buffer.
+ *
+ * @param p_instance A pointer to a Image object.
+ *
+ * @return Pointer to internal Image buffer.
+ *
+ * @see Image::ptr()
+ */
+typedef const uint8_t *(*GDExtensionInterfaceImagePtr)(GDExtensionObjectPtr p_instance);
+
+/* INTERFACE: WorkerThreadPool Utilities */
+
+/**
+ * @name worker_thread_pool_add_native_group_task
+ * @since 4.1
+ *
+ * Adds a group task to an instance of WorkerThreadPool.
+ *
+ * @param p_instance A pointer to a WorkerThreadPool object.
+ * @param p_func A pointer to a function to run in the thread pool.
+ * @param p_userdata A pointer to arbitrary data which will be passed to p_func.
+ * @param p_elements The number of element needed in the group.
+ * @param p_tasks The number of tasks needed in the group.
+ * @param p_high_priority Whether or not this is a high priority task.
+ * @param p_description A pointer to a String with the task description.
+ *
+ * @return The task group ID.
+ *
+ * @see WorkerThreadPool::add_group_task()
+ */
+typedef int64_t (*GDExtensionInterfaceWorkerThreadPoolAddNativeGroupTask)(GDExtensionObjectPtr p_instance, GDExtensionWorkerThreadPoolGroupTask p_func, void *p_userdata, int p_elements, int p_tasks, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
+
+/**
+ * @name worker_thread_pool_add_native_task
+ * @since 4.1
+ *
+ * Adds a task to an instance of WorkerThreadPool.
+ *
+ * @param p_instance A pointer to a WorkerThreadPool object.
+ * @param p_func A pointer to a function to run in the thread pool.
+ * @param p_userdata A pointer to arbitrary data which will be passed to p_func.
+ * @param p_high_priority Whether or not this is a high priority task.
+ * @param p_description A pointer to a String with the task description.
+ *
+ * @return The task ID.
+ */
+typedef int64_t (*GDExtensionInterfaceWorkerThreadPoolAddNativeTask)(GDExtensionObjectPtr p_instance, GDExtensionWorkerThreadPoolTask p_func, void *p_userdata, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
+
+/* INTERFACE: Packed Array */
+
+/**
+ * @name packed_byte_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a byte in a PackedByteArray.
+ *
+ * @param p_self A pointer to a PackedByteArray object.
+ * @param p_index The index of the byte to get.
+ *
+ * @return A pointer to the requested byte.
+ */
+typedef uint8_t *(*GDExtensionInterfacePackedByteArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_byte_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a byte in a PackedByteArray.
+ *
+ * @param p_self A const pointer to a PackedByteArray object.
+ * @param p_index The index of the byte to get.
+ *
+ * @return A const pointer to the requested byte.
+ */
+typedef const uint8_t *(*GDExtensionInterfacePackedByteArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float32_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a 32-bit float in a PackedFloat32Array.
+ *
+ * @param p_self A pointer to a PackedFloat32Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A pointer to the requested 32-bit float.
+ */
+typedef float *(*GDExtensionInterfacePackedFloat32ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float32_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a 32-bit float in a PackedFloat32Array.
+ *
+ * @param p_self A const pointer to a PackedFloat32Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A const pointer to the requested 32-bit float.
+ */
+typedef const float *(*GDExtensionInterfacePackedFloat32ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float64_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a 64-bit float in a PackedFloat64Array.
+ *
+ * @param p_self A pointer to a PackedFloat64Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A pointer to the requested 64-bit float.
+ */
+typedef double *(*GDExtensionInterfacePackedFloat64ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float64_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a 64-bit float in a PackedFloat64Array.
+ *
+ * @param p_self A const pointer to a PackedFloat64Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A const pointer to the requested 64-bit float.
+ */
+typedef const double *(*GDExtensionInterfacePackedFloat64ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int32_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a 32-bit integer in a PackedInt32Array.
+ *
+ * @param p_self A pointer to a PackedInt32Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A pointer to the requested 32-bit integer.
+ */
+typedef int32_t *(*GDExtensionInterfacePackedInt32ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int32_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a 32-bit integer in a PackedInt32Array.
+ *
+ * @param p_self A const pointer to a PackedInt32Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A const pointer to the requested 32-bit integer.
+ */
+typedef const int32_t *(*GDExtensionInterfacePackedInt32ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int64_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a 64-bit integer in a PackedInt64Array.
+ *
+ * @param p_self A pointer to a PackedInt64Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A pointer to the requested 64-bit integer.
+ */
+typedef int64_t *(*GDExtensionInterfacePackedInt64ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int64_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a 64-bit integer in a PackedInt64Array.
+ *
+ * @param p_self A const pointer to a PackedInt64Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A const pointer to the requested 64-bit integer.
+ */
+typedef const int64_t *(*GDExtensionInterfacePackedInt64ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_string_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a string in a PackedStringArray.
+ *
+ * @param p_self A pointer to a PackedStringArray object.
+ * @param p_index The index of the String to get.
+ *
+ * @return A pointer to the requested String.
+ */
+typedef GDExtensionStringPtr (*GDExtensionInterfacePackedStringArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_string_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a string in a PackedStringArray.
+ *
+ * @param p_self A const pointer to a PackedStringArray object.
+ * @param p_index The index of the String to get.
+ *
+ * @return A const pointer to the requested String.
+ */
+typedef GDExtensionStringPtr (*GDExtensionInterfacePackedStringArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector2_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a Vector2 in a PackedVector2Array.
+ *
+ * @param p_self A pointer to a PackedVector2Array object.
+ * @param p_index The index of the Vector2 to get.
+ *
+ * @return A pointer to the requested Vector2.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector2ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector2_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a Vector2 in a PackedVector2Array.
+ *
+ * @param p_self A const pointer to a PackedVector2Array object.
+ * @param p_index The index of the Vector2 to get.
+ *
+ * @return A const pointer to the requested Vector2.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector2ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector3_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a Vector3 in a PackedVector3Array.
+ *
+ * @param p_self A pointer to a PackedVector3Array object.
+ * @param p_index The index of the Vector3 to get.
+ *
+ * @return A pointer to the requested Vector3.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector3ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector3_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a Vector3 in a PackedVector3Array.
+ *
+ * @param p_self A const pointer to a PackedVector3Array object.
+ * @param p_index The index of the Vector3 to get.
+ *
+ * @return A const pointer to the requested Vector3.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector3ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector4_array_operator_index
+ * @since 4.3
+ *
+ * Gets a pointer to a Vector4 in a PackedVector4Array.
+ *
+ * @param p_self A pointer to a PackedVector4Array object.
+ * @param p_index The index of the Vector4 to get.
+ *
+ * @return A pointer to the requested Vector4.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector4ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector4_array_operator_index_const
+ * @since 4.3
+ *
+ * Gets a const pointer to a Vector4 in a PackedVector4Array.
+ *
+ * @param p_self A const pointer to a PackedVector4Array object.
+ * @param p_index The index of the Vector4 to get.
+ *
+ * @return A const pointer to the requested Vector4.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector4ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_color_array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a color in a PackedColorArray.
+ *
+ * @param p_self A pointer to a PackedColorArray object.
+ * @param p_index The index of the Color to get.
+ *
+ * @return A pointer to the requested Color.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedColorArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_color_array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a color in a PackedColorArray.
+ *
+ * @param p_self A const pointer to a PackedColorArray object.
+ * @param p_index The index of the Color to get.
+ *
+ * @return A const pointer to the requested Color.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedColorArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name array_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a Variant in an Array.
+ *
+ * @param p_self A pointer to an Array object.
+ * @param p_index The index of the Variant to get.
+ *
+ * @return A pointer to the requested Variant.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name array_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a Variant in an Array.
+ *
+ * @param p_self A const pointer to an Array object.
+ * @param p_index The index of the Variant to get.
+ *
+ * @return A const pointer to the requested Variant.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name array_ref
+ * @since 4.1
+ * @deprecated in Godot 4.5. use `Array::operator=` instead.
+ *
+ * Sets an Array to be a reference to another Array object.
+ *
+ * @param p_self A pointer to the Array object to update.
+ * @param p_from A pointer to the Array object to reference.
+ */
+typedef void (*GDExtensionInterfaceArrayRef)(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from);
+
+/**
+ * @name array_set_typed
+ * @since 4.1
+ *
+ * Makes an Array into a typed Array.
+ *
+ * @param p_self A pointer to the Array.
+ * @param p_type The type of Variant the Array will store.
+ * @param p_class_name A pointer to a StringName with the name of the object (if p_type is GDEXTENSION_VARIANT_TYPE_OBJECT).
+ * @param p_script A pointer to a Script object (if p_type is GDEXTENSION_VARIANT_TYPE_OBJECT and the base class is extended by a script).
+ */
+typedef void (*GDExtensionInterfaceArraySetTyped)(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script);
+
+/* INTERFACE: Dictionary */
+
+/**
+ * @name dictionary_operator_index
+ * @since 4.1
+ *
+ * Gets a pointer to a Variant in a Dictionary with the given key.
+ *
+ * @param p_self A pointer to a Dictionary object.
+ * @param p_key A pointer to a Variant representing the key.
+ *
+ * @return A pointer to a Variant representing the value at the given key.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceDictionaryOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionConstVariantPtr p_key);
+
+/**
+ * @name dictionary_operator_index_const
+ * @since 4.1
+ *
+ * Gets a const pointer to a Variant in a Dictionary with the given key.
+ *
+ * @param p_self A const pointer to a Dictionary object.
+ * @param p_key A pointer to a Variant representing the key.
+ *
+ * @return A const pointer to a Variant representing the value at the given key.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceDictionaryOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionConstVariantPtr p_key);
+
+/**
+ * @name dictionary_set_typed
+ * @since 4.4
+ *
+ * Makes a Dictionary into a typed Dictionary.
+ *
+ * @param p_self A pointer to the Dictionary.
+ * @param p_key_type The type of Variant the Dictionary key will store.
+ * @param p_key_class_name A pointer to a StringName with the name of the object (if p_key_type is GDEXTENSION_VARIANT_TYPE_OBJECT).
+ * @param p_key_script A pointer to a Script object (if p_key_type is GDEXTENSION_VARIANT_TYPE_OBJECT and the base class is extended by a script).
+ * @param p_value_type The type of Variant the Dictionary value will store.
+ * @param p_value_class_name A pointer to a StringName with the name of the object (if p_value_type is GDEXTENSION_VARIANT_TYPE_OBJECT).
+ * @param p_value_script A pointer to a Script object (if p_value_type is GDEXTENSION_VARIANT_TYPE_OBJECT and the base class is extended by a script).
+ */
+typedef void (*GDExtensionInterfaceDictionarySetTyped)(GDExtensionTypePtr p_self, GDExtensionVariantType p_key_type, GDExtensionConstStringNamePtr p_key_class_name, GDExtensionConstVariantPtr p_key_script, GDExtensionVariantType p_value_type, GDExtensionConstStringNamePtr p_value_class_name, GDExtensionConstVariantPtr p_value_script);
+
+/* INTERFACE: Object */
+
+/**
+ * @name object_method_bind_call
+ * @since 4.1
+ *
+ * Calls a method on an Object.
+ *
+ * @param p_method_bind A pointer to the MethodBind representing the method on the Object's class.
+ * @param p_instance A pointer to the Object.
+ * @param p_args A pointer to a C array of Variants representing the arguments.
+ * @param p_arg_count The number of arguments.
+ * @param r_ret A pointer to Variant which will receive the return value.
+ * @param r_error A pointer to a GDExtensionCallError struct that will receive error information.
+ */
+typedef void (*GDExtensionInterfaceObjectMethodBindCall)(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_arg_count, GDExtensionUninitializedVariantPtr r_ret, GDExtensionCallError *r_error);
+
+/**
+ * @name object_method_bind_ptrcall
+ * @since 4.1
+ *
+ * Calls a method on an Object (using a "ptrcall").
+ *
+ * @param p_method_bind A pointer to the MethodBind representing the method on the Object's class.
+ * @param p_instance A pointer to the Object.
+ * @param p_args A pointer to a C array representing the arguments.
+ * @param r_ret A pointer to the Object that will receive the return value.
+ */
+typedef void (*GDExtensionInterfaceObjectMethodBindPtrcall)(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
+
+/**
+ * @name object_destroy
+ * @since 4.1
+ *
+ * Destroys an Object.
+ *
+ * @param p_o A pointer to the Object.
+ */
+typedef void (*GDExtensionInterfaceObjectDestroy)(GDExtensionObjectPtr p_o);
+
+/**
+ * @name global_get_singleton
+ * @since 4.1
+ *
+ * Gets a global singleton by name.
+ *
+ * @param p_name A pointer to a StringName with the singleton name.
+ *
+ * @return A pointer to the singleton Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceGlobalGetSingleton)(GDExtensionConstStringNamePtr p_name);
+
+/**
+ * @name object_get_instance_binding
+ * @since 4.1
+ *
+ * Gets a pointer representing an Object's instance binding.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_token A token the library received by the GDExtension's entry point function.
+ * @param p_callbacks A pointer to a GDExtensionInstanceBindingCallbacks struct.
+ *
+ * @return A pointer to the instance binding.
+ */
+typedef void *(*GDExtensionInterfaceObjectGetInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+
+/**
+ * @name object_set_instance_binding
+ * @since 4.1
+ *
+ * Sets an Object's instance binding.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_token A token the library received by the GDExtension's entry point function.
+ * @param p_binding A pointer to the instance binding.
+ * @param p_callbacks A pointer to a GDExtensionInstanceBindingCallbacks struct.
+ */
+typedef void (*GDExtensionInterfaceObjectSetInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+
+/**
+ * @name object_free_instance_binding
+ * @since 4.2
+ *
+ * Free an Object's instance binding.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_token A token the library received by the GDExtension's entry point function.
+ */
+typedef void (*GDExtensionInterfaceObjectFreeInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token);
+
+/**
+ * @name object_set_instance
+ * @since 4.1
+ *
+ * Sets an extension class instance on a Object.
+ *
+ * `p_classname` should be a registered extension class and should extend the `p_o` Object's class.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_classname A pointer to a StringName with the registered extension class's name.
+ * @param p_instance A pointer to the extension class instance.
+ */
+typedef void (*GDExtensionInterfaceObjectSetInstance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance);
+
+/**
+ * @name object_get_class_name
+ * @since 4.1
+ *
+ * Gets the class name of an Object.
+ *
+ * If the GDExtension wraps the Godot object in an abstraction specific to its class, this is the
+ * function that should be used to determine which wrapper to use.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param r_class_name A pointer to a String to receive the class name.
+ *
+ * @return true if successful in getting the class name; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceObjectGetClassName)(GDExtensionConstObjectPtr p_object, GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringNamePtr r_class_name);
+
+/**
+ * @name object_cast_to
+ * @since 4.1
+ *
+ * Casts an Object to a different type.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_class_tag A pointer uniquely identifying a built-in class in the ClassDB.
+ *
+ * @return Returns a pointer to the Object, or NULL if it can't be cast to the requested type.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceObjectCastTo)(GDExtensionConstObjectPtr p_object, void *p_class_tag);
+
+/**
+ * @name object_get_instance_from_id
+ * @since 4.1
+ *
+ * Gets an Object by its instance ID.
+ *
+ * @param p_instance_id The instance ID.
+ *
+ * @return A pointer to the Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceObjectGetInstanceFromId)(GDObjectInstanceID p_instance_id);
+
+/**
+ * @name object_get_instance_id
+ * @since 4.1
+ *
+ * Gets the instance ID from an Object.
+ *
+ * @param p_object A pointer to the Object.
+ *
+ * @return The instance ID.
+ */
+typedef GDObjectInstanceID (*GDExtensionInterfaceObjectGetInstanceId)(GDExtensionConstObjectPtr p_object);
+
+/**
+ * @name object_has_script_method
+ * @since 4.3
+ *
+ * Checks if this object has a script with the given method.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_method A pointer to a StringName identifying the method.
+ *
+ * @return true if the object has a script and that script has a method with the given name. Returns false if the object has no script.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceObjectHasScriptMethod)(GDExtensionConstObjectPtr p_object, GDExtensionConstStringNamePtr p_method);
+
+/**
+ * @name object_call_script_method
+ * @since 4.3
+ *
+ * Call the given script method on this object.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_method A pointer to a StringName identifying the method.
+ * @param p_args A pointer to a C array of Variant.
+ * @param p_argument_count The number of arguments.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_error A pointer the structure which will hold error information.
+ */
+typedef void (*GDExtensionInterfaceObjectCallScriptMethod)(GDExtensionObjectPtr p_object, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
+
+/* INTERFACE: Reference */
+
+/**
+ * @name ref_get_object
+ * @since 4.1
+ *
+ * Gets the Object from a reference.
+ *
+ * @param p_ref A pointer to the reference.
+ *
+ * @return A pointer to the Object from the reference or NULL.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceRefGetObject)(GDExtensionConstRefPtr p_ref);
+
+/**
+ * @name ref_set_object
+ * @since 4.1
+ *
+ * Sets the Object referred to by a reference.
+ *
+ * @param p_ref A pointer to the reference.
+ * @param p_object A pointer to the Object to refer to.
+ */
+typedef void (*GDExtensionInterfaceRefSetObject)(GDExtensionRefPtr p_ref, GDExtensionObjectPtr p_object);
+
+/* INTERFACE: Script Instance */
+
+/**
+ * @name script_instance_create
+ * @since 4.1
+ * @deprecated in Godot 4.2. Use `script_instance_create3` instead.
+ *
+ * Creates a script instance that contains the given info and instance data.
+ *
+ * @param p_info A pointer to a GDExtensionScriptInstanceInfo struct.
+ * @param p_instance_data A pointer to a data representing the script instance in the GDExtension. This will be passed to all the function pointers on p_info.
+ *
+ * @return A pointer to a ScriptInstanceExtension object.
+ */
+typedef GDExtensionScriptInstancePtr (*GDExtensionInterfaceScriptInstanceCreate)(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data);
+
+/**
+ * @name script_instance_create2
+ * @since 4.2
+ * @deprecated in Godot 4.3. Use `script_instance_create3` instead.
+ *
+ * Creates a script instance that contains the given info and instance data.
+ *
+ * @param p_info A pointer to a GDExtensionScriptInstanceInfo2 struct.
+ * @param p_instance_data A pointer to a data representing the script instance in the GDExtension. This will be passed to all the function pointers on p_info.
+ *
+ * @return A pointer to a ScriptInstanceExtension object.
+ */
+typedef GDExtensionScriptInstancePtr (*GDExtensionInterfaceScriptInstanceCreate2)(const GDExtensionScriptInstanceInfo2 *p_info, GDExtensionScriptInstanceDataPtr p_instance_data);
+
+/**
+ * @name script_instance_create3
+ * @since 4.3
+ *
+ * Creates a script instance that contains the given info and instance data.
+ *
+ * @param p_info A pointer to a GDExtensionScriptInstanceInfo3 struct.
+ * @param p_instance_data A pointer to a data representing the script instance in the GDExtension. This will be passed to all the function pointers on p_info.
+ *
+ * @return A pointer to a ScriptInstanceExtension object.
+ */
+typedef GDExtensionScriptInstancePtr (*GDExtensionInterfaceScriptInstanceCreate3)(const GDExtensionScriptInstanceInfo3 *p_info, GDExtensionScriptInstanceDataPtr p_instance_data);
+
+/**
+ * @name placeholder_script_instance_create
+ * @since 4.2
+ *
+ * Creates a placeholder script instance for a given script and instance.
+ *
+ * This interface is optional as a custom placeholder could also be created with script_instance_create().
+ *
+ * @param p_language A pointer to a ScriptLanguage.
+ * @param p_script A pointer to a Script.
+ * @param p_owner A pointer to an Object.
+ *
+ * @return A pointer to a PlaceHolderScriptInstance object.
+ */
+typedef GDExtensionScriptInstancePtr (*GDExtensionInterfacePlaceHolderScriptInstanceCreate)(GDExtensionObjectPtr p_language, GDExtensionObjectPtr p_script, GDExtensionObjectPtr p_owner);
+
+/**
+ * @name placeholder_script_instance_update
+ * @since 4.2
+ *
+ * Updates a placeholder script instance with the given properties and values.
+ *
+ * The passed in placeholder must be an instance of PlaceHolderScriptInstance
+ * such as the one returned by placeholder_script_instance_create().
+ *
+ * @param p_placeholder A pointer to a PlaceHolderScriptInstance.
+ * @param p_properties A pointer to an Array of Dictionary representing PropertyInfo.
+ * @param p_values A pointer to a Dictionary mapping StringName to Variant values.
+ */
+typedef void (*GDExtensionInterfacePlaceHolderScriptInstanceUpdate)(GDExtensionScriptInstancePtr p_placeholder, GDExtensionConstTypePtr p_properties, GDExtensionConstTypePtr p_values);
+
+/**
+ * @name object_get_script_instance
+ * @since 4.2
+ *
+ * Get the script instance data attached to this object.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_language A pointer to the language expected for this script instance.
+ *
+ * @return A GDExtensionScriptInstanceDataPtr that was attached to this object as part of script_instance_create.
+ */
+typedef GDExtensionScriptInstanceDataPtr (*GDExtensionInterfaceObjectGetScriptInstance)(GDExtensionConstObjectPtr p_object, GDExtensionObjectPtr p_language);
+
+/**
+ * @name object_set_script_instance
+ * @since 4.5
+ *
+ * Set the script instance data attached to this object.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_script_instance A pointer to the script instance data to attach to this object.
+ */
+typedef void (*GDExtensionInterfaceObjectSetScriptInstance)(GDExtensionObjectPtr p_object, GDExtensionScriptInstanceDataPtr p_script_instance);
+
+/* INTERFACE: Callable */
+
+/**
+ * @name callable_custom_create
+ * @since 4.2
+ * @deprecated in Godot 4.3. Use `callable_custom_create2` instead.
+ *
+ * Creates a custom Callable object from a function pointer.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param r_callable A pointer that will receive the new Callable.
+ * @param p_callable_custom_info The info required to construct a Callable.
+ */
+typedef void (*GDExtensionInterfaceCallableCustomCreate)(GDExtensionUninitializedTypePtr r_callable, GDExtensionCallableCustomInfo *p_callable_custom_info);
+
+/**
+ * @name callable_custom_create2
+ * @since 4.3
+ *
+ * Creates a custom Callable object from a function pointer.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param r_callable A pointer that will receive the new Callable.
+ * @param p_callable_custom_info The info required to construct a Callable.
+ */
+typedef void (*GDExtensionInterfaceCallableCustomCreate2)(GDExtensionUninitializedTypePtr r_callable, GDExtensionCallableCustomInfo2 *p_callable_custom_info);
+
+/**
+ * @name callable_custom_get_userdata
+ * @since 4.2
+ *
+ * Retrieves the userdata pointer from a custom Callable.
+ *
+ * If the Callable is not a custom Callable or the token does not match the one provided to callable_custom_create() via GDExtensionCallableCustomInfo then NULL will be returned.
+ *
+ * @param p_callable A pointer to a Callable.
+ * @param p_token A pointer to an address that uniquely identifies the GDExtension.
+ *
+ * @return The userdata pointer given when creating this custom Callable.
+ */
+typedef void *(*GDExtensionInterfaceCallableCustomGetUserData)(GDExtensionConstTypePtr p_callable, void *p_token);
+
+/* INTERFACE: ClassDB */
+
+/**
+ * @name classdb_construct_object
+ * @since 4.1
+ * @deprecated in Godot 4.4. Use `classdb_construct_object2` instead.
+ *
+ * Constructs an Object of the requested class.
+ *
+ * The passed class must be a built-in godot class, or an already-registered extension class. In both cases, object_set_instance() should be called to fully initialize the object.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ *
+ * @return A pointer to the newly created Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceClassdbConstructObject)(GDExtensionConstStringNamePtr p_classname);
+
+/**
+ * @name classdb_construct_object2
+ * @since 4.4
+ *
+ * Constructs an Object of the requested class.
+ *
+ * The passed class must be a built-in godot class, or an already-registered extension class. In both cases, object_set_instance() should be called to fully initialize the object.
+ *
+ * "NOTIFICATION_POSTINITIALIZE" must be sent after construction.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ *
+ * @return A pointer to the newly created Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceClassdbConstructObject2)(GDExtensionConstStringNamePtr p_classname);
+
+/**
+ * @name classdb_get_method_bind
+ * @since 4.1
+ *
+ * Gets a pointer to the MethodBind in ClassDB for the given class, method and hash.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ * @param p_methodname A pointer to a StringName with the method name.
+ * @param p_hash A hash representing the function signature.
+ *
+ * @return A pointer to the MethodBind from ClassDB.
+ */
+typedef GDExtensionMethodBindPtr (*GDExtensionInterfaceClassdbGetMethodBind)(GDExtensionConstStringNamePtr p_classname, GDExtensionConstStringNamePtr p_methodname, GDExtensionInt p_hash);
+
+/**
+ * @name classdb_get_class_tag
+ * @since 4.1
+ *
+ * Gets a pointer uniquely identifying the given built-in class in the ClassDB.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ *
+ * @return A pointer uniquely identifying the built-in class in the ClassDB.
+ */
+typedef void *(*GDExtensionInterfaceClassdbGetClassTag)(GDExtensionConstStringNamePtr p_classname);
+
+/* INTERFACE: ClassDB Extension */
+
+/**
+ * @name classdb_register_extension_class
+ * @since 4.1
+ * @deprecated in Godot 4.2. Use `classdb_register_extension_class4` instead.
+ *
+ * Registers an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_parent_class_name A pointer to a StringName with the parent class name.
+ * @param p_extension_funcs A pointer to a GDExtensionClassCreationInfo struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo *p_extension_funcs);
+
+/**
+ * @name classdb_register_extension_class2
+ * @since 4.2
+ * @deprecated in Godot 4.3. Use `classdb_register_extension_class4` instead.
+ *
+ * Registers an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_parent_class_name A pointer to a StringName with the parent class name.
+ * @param p_extension_funcs A pointer to a GDExtensionClassCreationInfo2 struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass2)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo2 *p_extension_funcs);
+
+/**
+ * @name classdb_register_extension_class3
+ * @since 4.3
+ * @deprecated in Godot 4.4. Use `classdb_register_extension_class4` instead.
+ *
+ * Registers an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_parent_class_name A pointer to a StringName with the parent class name.
+ * @param p_extension_funcs A pointer to a GDExtensionClassCreationInfo3 struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass3)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo3 *p_extension_funcs);
+
+/**
+ * @name classdb_register_extension_class4
+ * @since 4.4
+ * @deprecated in Godot 4.5. Use `classdb_register_extension_class5` instead.
+ *
+ * Registers an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_parent_class_name A pointer to a StringName with the parent class name.
+ * @param p_extension_funcs A pointer to a GDExtensionClassCreationInfo4 struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass4)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo4 *p_extension_funcs);
+
+/**
+ * @name classdb_register_extension_class5
+ * @since 4.5
+ *
+ * Registers an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_parent_class_name A pointer to a StringName with the parent class name.
+ * @param p_extension_funcs A pointer to a GDExtensionClassCreationInfo5 struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass5)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo5 *p_extension_funcs);
+
+/**
+ * @name classdb_register_extension_class_method
+ * @since 4.1
+ *
+ * Registers a method on an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_method_info A pointer to a GDExtensionClassMethodInfo struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassMethod)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassMethodInfo *p_method_info);
+
+/**
+ * @name classdb_register_extension_class_virtual_method
+ * @since 4.3
+ *
+ * Registers a virtual method on an extension class in ClassDB, that can be implemented by scripts or other extensions.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_method_info A pointer to a GDExtensionClassMethodInfo struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassVirtualMethod)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassVirtualMethodInfo *p_method_info);
+
+/**
+ * @name classdb_register_extension_class_integer_constant
+ * @since 4.1
+ *
+ * Registers an integer constant on an extension class in the ClassDB.
+ *
+ * Note about registering bitfield values (if p_is_bitfield is true): even though p_constant_value is signed, language bindings are
+ * advised to treat bitfields as uint64_t, since this is generally clearer and can prevent mistakes like using -1 for setting all bits.
+ * Language APIs should thus provide an abstraction that registers bitfields (uint64_t) separately from regular constants (int64_t).
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_enum_name A pointer to a StringName with the enum name.
+ * @param p_constant_name A pointer to a StringName with the constant name.
+ * @param p_constant_value The constant value.
+ * @param p_is_bitfield Whether or not this constant is part of a bitfield.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassIntegerConstant)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_enum_name, GDExtensionConstStringNamePtr p_constant_name, GDExtensionInt p_constant_value, GDExtensionBool p_is_bitfield);
+
+/**
+ * @name classdb_register_extension_class_property
+ * @since 4.1
+ *
+ * Registers a property on an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_info A pointer to a GDExtensionPropertyInfo struct.
+ * @param p_setter A pointer to a StringName with the name of the setter method.
+ * @param p_getter A pointer to a StringName with the name of the getter method.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassProperty)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionPropertyInfo *p_info, GDExtensionConstStringNamePtr p_setter, GDExtensionConstStringNamePtr p_getter);
+
+/**
+ * @name classdb_register_extension_class_property_indexed
+ * @since 4.2
+ *
+ * Registers an indexed property on an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_info A pointer to a GDExtensionPropertyInfo struct.
+ * @param p_setter A pointer to a StringName with the name of the setter method.
+ * @param p_getter A pointer to a StringName with the name of the getter method.
+ * @param p_index The index to pass as the first argument to the getter and setter methods.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassPropertyIndexed)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionPropertyInfo *p_info, GDExtensionConstStringNamePtr p_setter, GDExtensionConstStringNamePtr p_getter, GDExtensionInt p_index);
+
+/**
+ * @name classdb_register_extension_class_property_group
+ * @since 4.1
+ *
+ * Registers a property group on an extension class in the ClassDB.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_group_name A pointer to a String with the group name.
+ * @param p_prefix A pointer to a String with the prefix used by properties in this group.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassPropertyGroup)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringPtr p_group_name, GDExtensionConstStringPtr p_prefix);
+
+/**
+ * @name classdb_register_extension_class_property_subgroup
+ * @since 4.1
+ *
+ * Registers a property subgroup on an extension class in the ClassDB.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_subgroup_name A pointer to a String with the subgroup name.
+ * @param p_prefix A pointer to a String with the prefix used by properties in this subgroup.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringPtr p_subgroup_name, GDExtensionConstStringPtr p_prefix);
+
+/**
+ * @name classdb_register_extension_class_signal
+ * @since 4.1
+ *
+ * Registers a signal on an extension class in the ClassDB.
+ *
+ * Provided structs can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_signal_name A pointer to a StringName with the signal name.
+ * @param p_argument_info A pointer to a GDExtensionPropertyInfo struct.
+ * @param p_argument_count The number of arguments the signal receives.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassSignal)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_signal_name, const GDExtensionPropertyInfo *p_argument_info, GDExtensionInt p_argument_count);
+
+/**
+ * @name classdb_unregister_extension_class
+ * @since 4.1
+ *
+ * Unregisters an extension class in the ClassDB.
+ *
+ * Unregistering a parent class before a class that inherits it will result in failure. Inheritors must be unregistered first.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ */
+typedef void (*GDExtensionInterfaceClassdbUnregisterExtensionClass)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name);
+
+/**
+ * @name get_library_path
+ * @since 4.1
+ *
+ * Gets the path to the current GDExtension library.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param r_path A pointer to a String which will receive the path.
+ */
+typedef void (*GDExtensionInterfaceGetLibraryPath)(GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringPtr r_path);
+
+/**
+ * @name editor_add_plugin
+ * @since 4.1
+ *
+ * Adds an editor plugin.
+ *
+ * It's safe to call during initialization.
+ *
+ * @param p_class_name A pointer to a StringName with the name of a class (descending from EditorPlugin) which is already registered with ClassDB.
+ */
+typedef void (*GDExtensionInterfaceEditorAddPlugin)(GDExtensionConstStringNamePtr p_class_name);
+
+/**
+ * @name editor_remove_plugin
+ * @since 4.1
+ *
+ * Removes an editor plugin.
+ *
+ * @param p_class_name A pointer to a StringName with the name of a class that was previously added as an editor plugin.
+ */
+typedef void (*GDExtensionInterfaceEditorRemovePlugin)(GDExtensionConstStringNamePtr p_class_name);
+
+/**
+ * @name editor_help_load_xml_from_utf8_chars
+ * @since 4.3
+ *
+ * Loads new XML-formatted documentation data in the editor.
+ *
+ * The provided pointer can be immediately freed once the function returns.
+ *
+ * @param p_data A pointer to a UTF-8 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *p_data);
+
+/**
+ * @name editor_help_load_xml_from_utf8_chars_and_len
+ * @since 4.3
+ *
+ * Loads new XML-formatted documentation data in the editor.
+ *
+ * The provided pointer can be immediately freed once the function returns.
+ *
+ * @param p_data A pointer to a UTF-8 encoded C string.
+ * @param p_size The number of bytes (not code units).
+ */
+typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const char *p_data, GDExtensionInt p_size);
+
+/**
+ * @name editor_register_get_classes_used_callback
+ * @since 4.5
+ *
+ * Registers a callback that Godot can call to get the list of all classes (from ClassDB) that may be used by the calling GDExtension.
+ *
+ * This is used by the editor to generate a build profile (in "Tools" > "Engine Compilation Configuration Editor..." > "Detect from project"),
+ * in order to recompile Godot with only the classes used.
+ * In the provided callback, the GDExtension should provide the list of classes that _may_ be used statically, thus the time of invocation shouldn't matter.
+ * If a GDExtension doesn't register a callback, Godot will assume that it could be using any classes.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_callback The callback to retrieve the list of classes used.
+ */
+typedef void (*GDExtensionInterfaceEditorRegisterGetClassesUsedCallback)(GDExtensionClassLibraryPtr p_library, GDExtensionEditorGetClassesUsedCallback p_callback);
+
+/**
+ * @name register_main_loop_callbacks
+ * @since 4.5
+ *
+ * Registers callbacks to be called at different phases of the main loop.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_callbacks A pointer to the structure that contains the callbacks.
+ */
+typedef void (*GDExtensionInterfaceRegisterMainLoopCallbacks)(GDExtensionClassLibraryPtr p_library, const GDExtensionMainLoopCallbacks *p_callbacks);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platforms/godot/src/colyseus_client.c
+++ b/platforms/godot/src/colyseus_client.c
@@ -1,7 +1,9 @@
 #include "godot_colyseus.h"
 #include <colyseus/client.h>
+#include <colyseus/settings.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 // Helper function to create a Godot String from a C string
 static void string_from_c_str(String *p_dest, const char *p_src) {
@@ -14,21 +16,134 @@ static void string_from_c_str(String *p_dest, const char *p_src) {
 
 // Helper function to convert Godot String to C string (caller must free)
 static char* string_to_c_str(const String *p_src) {
-    // For now, return a dummy string. We'll implement proper conversion later
-    // when we need actual string data from Godot
-    return strdup("");
+    if (!p_src) return strdup("");
+    
+    // Get string length
+    int32_t length = api.string_to_utf8_chars(p_src, NULL, 0);
+    if (length <= 0) return strdup("");
+    
+    // Allocate buffer (+1 for null terminator)
+    char* buffer = (char*)malloc(length + 1);
+    if (!buffer) return strdup("");
+    
+    // Extract string
+    api.string_to_utf8_chars(p_src, buffer, length);
+    buffer[length] = '\0';
+    
+    return buffer;
 }
+
+// Helper to parse endpoint string (e.g., "ws://localhost:2567")
+static void parse_endpoint(const char* endpoint, char** address, char** port, bool* use_secure) {
+    if (!endpoint) return;
+    
+    // Check protocol
+    if (strncmp(endpoint, "wss://", 6) == 0) {
+        *use_secure = true;
+        endpoint += 6;
+    } else if (strncmp(endpoint, "ws://", 5) == 0) {
+        *use_secure = false;
+        endpoint += 5;
+    } else if (strncmp(endpoint, "https://", 8) == 0) {
+        *use_secure = true;
+        endpoint += 8;
+    } else if (strncmp(endpoint, "http://", 7) == 0) {
+        *use_secure = false;
+        endpoint += 7;
+    }
+    
+    // Find port separator
+    const char* colon = strchr(endpoint, ':');
+    const char* slash = strchr(endpoint, '/');
+    
+    if (colon && (!slash || colon < slash)) {
+        // Has port
+        size_t addr_len = colon - endpoint;
+        *address = (char*)malloc(addr_len + 1);
+        strncpy(*address, endpoint, addr_len);
+        (*address)[addr_len] = '\0';
+        
+        // Extract port
+        const char* port_start = colon + 1;
+        const char* port_end = slash ? slash : (port_start + strlen(port_start));
+        size_t port_len = port_end - port_start;
+        *port = (char*)malloc(port_len + 1);
+        strncpy(*port, port_start, port_len);
+        (*port)[port_len] = '\0';
+    } else {
+        // No port, just address
+        const char* addr_end = slash ? slash : (endpoint + strlen(endpoint));
+        size_t addr_len = addr_end - endpoint;
+        *address = (char*)malloc(addr_len + 1);
+        strncpy(*address, endpoint, addr_len);
+        (*address)[addr_len] = '\0';
+        
+        *port = strdup(*use_secure ? "443" : "80");
+    }
+}
+
+// Forward declaration for callbacks
+static void on_join_or_create_success(colyseus_room_t* room, void* userdata);
+static void on_join_or_create_error(int code, const char* message, void* userdata);
+
+// Room event callbacks
+static void on_room_join(void* userdata);
+static void on_room_state_change(void* userdata);
+static void on_room_error(int code, const char* message, void* userdata);
+static void on_room_leave(int code, const char* reason, void* userdata);
 
 GDExtensionObjectPtr gdext_colyseus_client_constructor(void* p_class_userdata) {
     (void)p_class_userdata;
     
+    printf("[ColyseusClient] Constructor called\n");
+    fflush(stdout);
+    
+    // Create the Godot Object (construct parent RefCounted class)
+    StringName class_name;
+    constructors.string_name_new_with_latin1_chars(&class_name, "RefCounted", false);
+    
+    GDExtensionObjectPtr object = api.classdb_construct_object(&class_name);
+    destructors.string_name_destructor(&class_name);
+    
+    if (!object) {
+        printf("[ColyseusClient] ERROR: Failed to construct Godot object!\n");
+        fflush(stdout);
+        return NULL;
+    }
+    
+    printf("[ColyseusClient] Godot object created: %p\n", (void*)object);
+    fflush(stdout);
+    
+    // Create our wrapper instance data
     ColyseusClientWrapper* wrapper = (ColyseusClientWrapper*)malloc(sizeof(ColyseusClientWrapper));
+    if (!wrapper) {
+        printf("[ColyseusClient] ERROR: Failed to allocate wrapper!\n");
+        fflush(stdout);
+        return NULL;
+    }
+    
     wrapper->native_client = NULL; // Will be initialized on connect
-    return (GDExtensionObjectPtr)wrapper;
+    
+    printf("[ColyseusClient] Wrapper created: %p\n", (void*)wrapper);
+    fflush(stdout);
+    
+    // Attach our wrapper to the Godot object
+    StringName class_name2;
+    constructors.string_name_new_with_latin1_chars(&class_name2, "ColyseusClient", false);
+    api.object_set_instance(object, &class_name2, wrapper);
+    destructors.string_name_destructor(&class_name2);
+    
+    printf("[ColyseusClient] Wrapper attached to object\n");
+    fflush(stdout);
+    
+    return object;
 }
 
 void gdext_colyseus_client_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
     (void)p_class_userdata;
+    
+    printf("[ColyseusClient] Destructor called for instance: %p\n", p_instance);
+    fflush(stdout);
     
     ColyseusClientWrapper* wrapper = (ColyseusClientWrapper*)p_instance;
     if (wrapper) {
@@ -39,21 +154,84 @@ void gdext_colyseus_client_destructor(void* p_class_userdata, GDExtensionClassIn
     }
 }
 
+// Reference counting for RefCounted base class
+void gdext_colyseus_client_reference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
+    (void)p_class_userdata;
+    (void)p_instance;
+    // For RefCounted, Godot manages the reference count internally
+    // We don't need to do anything here
+    printf("[ColyseusClient] Reference called\n");
+    fflush(stdout);
+}
+
+void gdext_colyseus_client_unreference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
+    (void)p_class_userdata;
+    (void)p_instance;
+    // For RefCounted, Godot manages the reference count internally
+    // We don't need to do anything here
+    printf("[ColyseusClient] Unreference called\n");
+    fflush(stdout);
+}
+
 void gdext_colyseus_client_connect_to(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
     (void)p_method_userdata;
     (void)r_ret; // void return
     
+    printf("[ColyseusClient] connect_to called with instance: %p\n", p_instance);
+    fflush(stdout);
+    
     // p_args[0] is a pointer to a String (GDExtensionStringPtr)
     const String* endpoint = (const String*)p_args[0];
     
+    printf("[ColyseusClient] String pointer: %p\n", (void*)endpoint);
+    fflush(stdout);
+    
     ColyseusClientWrapper* wrapper = (ColyseusClientWrapper*)p_instance;
-    if (wrapper) {
-        char* endpoint_str = string_to_c_str(endpoint);
-        // TODO: Use endpoint_str to connect
-        if (endpoint_str) {
-            free(endpoint_str);
-        }
+    if (!wrapper) {
+        printf("[ColyseusClient] ERROR: wrapper is NULL!\n");
+        fflush(stdout);
+        return;
     }
+    
+    printf("[ColyseusClient] Wrapper valid: %p\n", (void*)wrapper);
+    fflush(stdout);
+    
+    // Extract the endpoint string
+    char* endpoint_str = string_to_c_str(endpoint);
+    if (!endpoint_str) return;
+    
+    printf("[ColyseusClient] Connecting to: %s\n", endpoint_str);
+    fflush(stdout);
+    
+    // Parse endpoint and create settings
+    char* address = NULL;
+    char* port = NULL;
+    bool use_secure = false;
+    
+    parse_endpoint(endpoint_str, &address, &port, &use_secure);
+    
+    printf("[ColyseusClient] Parsed - address: %s, port: %s, secure: %d\n", address, port, use_secure);
+    fflush(stdout);
+    
+    // Create settings
+    colyseus_settings_t* settings = colyseus_settings_create();
+    colyseus_settings_set_address(settings, address);
+    colyseus_settings_set_port(settings, port);
+    colyseus_settings_set_secure(settings, use_secure);
+    
+    // Create native client
+    if (wrapper->native_client) {
+        colyseus_client_free(wrapper->native_client);
+    }
+    wrapper->native_client = colyseus_client_create(settings);
+    
+    printf("[ColyseusClient] Native client created\n");
+    fflush(stdout);
+    
+    // Cleanup
+    free(endpoint_str);
+    free(address);
+    free(port);
 }
 
 // Simple getter - reference implementation style
@@ -76,4 +254,200 @@ void gdext_colyseus_client_get_endpoint_wrapper(void* p_method_userdata, GDExten
         const char* endpoint = gdext_colyseus_client_get_endpoint(self);
         string_from_c_str((String*)r_ret, endpoint);
     }
+}
+
+// Helper function to emit Godot signals
+static void emit_signal(GDExtensionObjectPtr object, const char* signal_name, GDExtensionConstVariantPtr* args, int arg_count) {
+    if (!object) return;
+    
+    // Get object_emit_signal function pointer
+    GDExtensionInterfaceObjectMethodBindPtrcall object_emit_signal = 
+        (GDExtensionInterfaceObjectMethodBindPtrcall)api.classdb_construct_object; // placeholder
+    
+    // TODO: Properly implement signal emission
+    // For now we'll just log it
+    printf("[ColyseusRoom] Would emit signal: %s\n", signal_name);
+    fflush(stdout);
+}
+
+// Room event callbacks
+static void on_room_join(void* userdata) {
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)userdata;
+    if (!room_wrapper) return;
+    
+    printf("[ColyseusRoom] Joined room!\n");
+    fflush(stdout);
+    
+    // Emit "joined" signal
+    emit_signal(room_wrapper->godot_object, "joined", NULL, 0);
+}
+
+static void on_room_state_change(void* userdata) {
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)userdata;
+    if (!room_wrapper) return;
+    
+    printf("[ColyseusRoom] State changed\n");
+    fflush(stdout);
+    
+    // Emit "state_changed" signal
+    emit_signal(room_wrapper->godot_object, "state_changed", NULL, 0);
+}
+
+static void on_room_error(int code, const char* message, void* userdata) {
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)userdata;
+    if (!room_wrapper) return;
+    
+    printf("[ColyseusRoom] Error [%d]: %s\n", code, message);
+    fflush(stdout);
+    
+    // TODO: Emit "error" signal with code and message
+}
+
+static void on_room_leave(int code, const char* reason, void* userdata) {
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)userdata;
+    if (!room_wrapper) return;
+    
+    printf("[ColyseusRoom] Left room [%d]: %s\n", code, reason);
+    fflush(stdout);
+    
+    // TODO: Emit "left" signal with code and reason
+}
+
+// Matchmaking success callback
+static void on_join_or_create_success(colyseus_room_t* room, void* userdata) {
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)userdata;
+    if (!room_wrapper) return;
+    
+    printf("[ColyseusClient] Join/Create success! Room: %p\n", (void*)room);
+    fflush(stdout);
+    
+    // Store the native room
+    room_wrapper->native_room = room;
+    
+    // Register room event callbacks
+    colyseus_room_on_join(room, on_room_join, room_wrapper);
+    colyseus_room_on_state_change(room, on_room_state_change, room_wrapper);
+    colyseus_room_on_error(room, on_room_error, room_wrapper);
+    colyseus_room_on_leave(room, on_room_leave, room_wrapper);
+    
+    printf("[ColyseusClient] Room callbacks registered\n");
+    fflush(stdout);
+}
+
+// Matchmaking error callback
+static void on_join_or_create_error(int code, const char* message, void* userdata) {
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)userdata;
+    
+    printf("[ColyseusClient] Join/Create error [%d]: %s\n", code, message);
+    fflush(stdout);
+    
+    // Emit error on the room object
+    if (room_wrapper) {
+        on_room_error(code, message, room_wrapper);
+    }
+}
+
+// join_or_create implementation (ptrcall version)
+void gdext_colyseus_client_join_or_create_ptrcall(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    
+    printf("[ColyseusClient] join_or_create called\n");
+    fflush(stdout);
+    
+    ColyseusClientWrapper* client_wrapper = (ColyseusClientWrapper*)p_instance;
+    if (!client_wrapper || !client_wrapper->native_client) {
+        printf("[ColyseusClient] ERROR: Client not connected!\n");
+        fflush(stdout);
+        // Return null object
+        if (r_ret) {
+            GDExtensionObjectPtr null_obj = NULL;
+            constructors.variant_from_object_constructor(r_ret, &null_obj);
+        }
+        return;
+    }
+    
+    // p_args[0] is a pointer to a String (room name)
+    const String* room_name_string = (const String*)p_args[0];
+    char* room_name = string_to_c_str(room_name_string);
+    
+    printf("[ColyseusClient] Room name: %s\n", room_name);
+    fflush(stdout);
+    
+    // Create a ColyseusRoom Godot object
+    // This will call our constructor (gdext_colyseus_room_constructor) automatically
+    StringName class_name;
+    constructors.string_name_new_with_latin1_chars(&class_name, "ColyseusRoom", false);
+    
+    GDExtensionObjectPtr room_object = api.classdb_construct_object(&class_name);
+    destructors.string_name_destructor(&class_name);
+    
+    if (!room_object) {
+        printf("[ColyseusClient] ERROR: Failed to construct ColyseusRoom object!\n");
+        fflush(stdout);
+        free(room_name);
+        // Return null object
+        if (r_ret) {
+            GDExtensionObjectPtr null_obj = NULL;
+            constructors.variant_from_object_constructor(r_ret, &null_obj);
+        }
+        return;
+    }
+    
+    printf("[ColyseusClient] ColyseusRoom object created: %p\n", (void*)room_object);
+    fflush(stdout);
+    
+    // Get the wrapper instance that was created by our constructor
+    // The wrapper is the instance pointer associated with the object
+    // Since we just created it, the wrapper is the object itself for now (we need to get the binding)
+    // For extension classes, the instance IS the wrapper we returned from constructor
+    ColyseusRoomWrapper* room_wrapper = (ColyseusRoomWrapper*)room_object;
+    
+    // Store the Godot object reference
+    room_wrapper->godot_object = room_object;
+    
+    printf("[ColyseusClient] Room wrapper: %p\n", (void*)room_wrapper);
+    fflush(stdout);
+    
+    // Call native join_or_create (async)
+    colyseus_client_join_or_create(
+        client_wrapper->native_client,
+        room_name,
+        "{}",  // Empty options for now
+        on_join_or_create_success,
+        on_join_or_create_error,
+        room_wrapper
+    );
+    
+    printf("[ColyseusClient] Native join_or_create called\n");
+    fflush(stdout);
+    
+    // Return the room object (ptrcall - write object pointer directly)
+    if (r_ret) {
+        *(GDExtensionObjectPtr*)r_ret = room_object;
+    }
+    
+    free(room_name);
+}
+
+// join_or_create implementation (call version - with Variants)
+void gdext_colyseus_client_join_or_create(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr* p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError* r_error) {
+    (void)p_method_userdata;
+    (void)p_argument_count;
+    (void)r_error;
+    
+    // Extract the string argument from variant
+    String room_name_string;
+    constructors.string_from_variant_constructor(&room_name_string, p_args[0]);
+    
+    // Call the ptrcall version with converted arguments
+    GDExtensionObjectPtr result = NULL;
+    gdext_colyseus_client_join_or_create_ptrcall(p_method_userdata, p_instance, (const GDExtensionConstTypePtr*)&room_name_string, &result);
+    
+    // Convert result to variant
+    if (r_return) {
+        constructors.variant_from_object_constructor(r_return, &result);
+    }
+    
+    // Cleanup
+    destructors.string_destructor(&room_name_string);
 }

--- a/platforms/godot/src/colyseus_client.c
+++ b/platforms/godot/src/colyseus_client.c
@@ -1,0 +1,79 @@
+#include "godot_colyseus.h"
+#include <colyseus/client.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Helper function to create a Godot String from a C string
+static void string_from_c_str(String *p_dest, const char *p_src) {
+    if (p_src == NULL) {
+        constructors.string_new_with_utf8_chars(p_dest, "");
+    } else {
+        constructors.string_new_with_utf8_chars(p_dest, p_src);
+    }
+}
+
+// Helper function to convert Godot String to C string (caller must free)
+static char* string_to_c_str(const String *p_src) {
+    // For now, return a dummy string. We'll implement proper conversion later
+    // when we need actual string data from Godot
+    return strdup("");
+}
+
+GDExtensionObjectPtr gdext_colyseus_client_constructor(void* p_class_userdata) {
+    (void)p_class_userdata;
+    
+    ColyseusClientWrapper* wrapper = (ColyseusClientWrapper*)malloc(sizeof(ColyseusClientWrapper));
+    wrapper->native_client = NULL; // Will be initialized on connect
+    return (GDExtensionObjectPtr)wrapper;
+}
+
+void gdext_colyseus_client_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
+    (void)p_class_userdata;
+    
+    ColyseusClientWrapper* wrapper = (ColyseusClientWrapper*)p_instance;
+    if (wrapper) {
+        if (wrapper->native_client) {
+            colyseus_client_free(wrapper->native_client);
+        }
+        free(wrapper);
+    }
+}
+
+void gdext_colyseus_client_connect_to(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)r_ret; // void return
+    
+    // p_args[0] is a pointer to a String (GDExtensionStringPtr)
+    const String* endpoint = (const String*)p_args[0];
+    
+    ColyseusClientWrapper* wrapper = (ColyseusClientWrapper*)p_instance;
+    if (wrapper) {
+        char* endpoint_str = string_to_c_str(endpoint);
+        // TODO: Use endpoint_str to connect
+        if (endpoint_str) {
+            free(endpoint_str);
+        }
+    }
+}
+
+// Simple getter - reference implementation style
+const char* gdext_colyseus_client_get_endpoint(const ColyseusClientWrapper* self) {
+    if (self && self->native_client && self->native_client->settings) {
+        // Note: This returns a pointer to the settings structure data
+        // The string is managed by the settings object and should not be freed by the caller
+        return self->native_client->settings->server_address;
+    }
+    return "";
+}
+
+// GDExtension wrapper for the simple getter
+void gdext_colyseus_client_get_endpoint_wrapper(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)p_args; // no arguments
+    
+    const ColyseusClientWrapper* self = (const ColyseusClientWrapper*)p_instance;
+    if (self && r_ret) {
+        const char* endpoint = gdext_colyseus_client_get_endpoint(self);
+        string_from_c_str((String*)r_ret, endpoint);
+    }
+}

--- a/platforms/godot/src/colyseus_room.c
+++ b/platforms/godot/src/colyseus_room.c
@@ -2,10 +2,7 @@
 #include <colyseus/room.h>
 #include <stdlib.h>
 #include <string.h>
-
-typedef struct {
-    colyseus_room_t* native_room;
-} ColyseusRoomWrapper;
+#include <stdio.h>
 
 // Helper function to create a Godot String from a C string
 static void string_from_c_str(String *p_dest, const char *p_src) {
@@ -21,11 +18,15 @@ GDExtensionObjectPtr gdext_colyseus_room_constructor(void* p_class_userdata) {
     
     ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)malloc(sizeof(ColyseusRoomWrapper));
     wrapper->native_room = NULL; // Will be set when joining
+    wrapper->godot_object = NULL; // Will be set when returned from join_or_create
     return (GDExtensionObjectPtr)wrapper;
 }
 
 void gdext_colyseus_room_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
     (void)p_class_userdata;
+    
+    printf("[ColyseusRoom] Destructor called for instance: %p\n", p_instance);
+    fflush(stdout);
     
     ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
     if (wrapper) {
@@ -34,6 +35,21 @@ void gdext_colyseus_room_destructor(void* p_class_userdata, GDExtensionClassInst
         }
         free(wrapper);
     }
+}
+
+// Reference counting for RefCounted base class
+void gdext_colyseus_room_reference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
+    (void)p_class_userdata;
+    (void)p_instance;
+    printf("[ColyseusRoom] Reference called\n");
+    fflush(stdout);
+}
+
+void gdext_colyseus_room_unreference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
+    (void)p_class_userdata;
+    (void)p_instance;
+    printf("[ColyseusRoom] Unreference called\n");
+    fflush(stdout);
 }
 
 void gdext_colyseus_room_send_message(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {

--- a/platforms/godot/src/colyseus_room.c
+++ b/platforms/godot/src/colyseus_room.c
@@ -1,0 +1,121 @@
+#include "godot_colyseus.h"
+#include <colyseus/room.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    colyseus_room_t* native_room;
+} ColyseusRoomWrapper;
+
+// Helper function to create a Godot String from a C string
+static void string_from_c_str(String *p_dest, const char *p_src) {
+    if (p_src == NULL) {
+        constructors.string_new_with_utf8_chars(p_dest, "");
+    } else {
+        constructors.string_new_with_utf8_chars(p_dest, p_src);
+    }
+}
+
+GDExtensionObjectPtr gdext_colyseus_room_constructor(void* p_class_userdata) {
+    (void)p_class_userdata;
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)malloc(sizeof(ColyseusRoomWrapper));
+    wrapper->native_room = NULL; // Will be set when joining
+    return (GDExtensionObjectPtr)wrapper;
+}
+
+void gdext_colyseus_room_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance) {
+    (void)p_class_userdata;
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper) {
+        if (wrapper->native_room) {
+            colyseus_room_free(wrapper->native_room);
+        }
+        free(wrapper);
+    }
+}
+
+void gdext_colyseus_room_send_message(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)r_ret; // void return
+    
+    // p_args[0] is a pointer to a String
+    // p_args[1] is a pointer to a PackedByteArray
+    (void)p_args;
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room) {
+        // TODO: Extract String and PackedByteArray from p_args and send message
+    }
+}
+
+void gdext_colyseus_room_send_message_int(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)r_ret; // void return
+    
+    // p_args[0] is a pointer to an int64_t (Godot's int)
+    // p_args[1] is a pointer to a PackedByteArray
+    (void)p_args;
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room) {
+        // TODO: Extract int and PackedByteArray from p_args and send message
+    }
+}
+
+void gdext_colyseus_room_leave(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)p_args; // no arguments
+    (void)r_ret; // void return
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room) {
+        colyseus_room_leave(wrapper->native_room, false);
+    }
+}
+
+void gdext_colyseus_room_get_id(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)p_args; // no arguments
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room && r_ret) {
+        const char* id = colyseus_room_get_id(wrapper->native_room);
+        string_from_c_str((String*)r_ret, id);
+    }
+}
+
+void gdext_colyseus_room_get_session_id(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)p_args; // no arguments
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room && r_ret) {
+        const char* session_id = colyseus_room_get_session_id(wrapper->native_room);
+        string_from_c_str((String*)r_ret, session_id);
+    }
+}
+
+void gdext_colyseus_room_get_name(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)p_args; // no arguments
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room && r_ret) {
+        const char* name = colyseus_room_get_name(wrapper->native_room);
+        string_from_c_str((String*)r_ret, name);
+    }
+}
+
+void gdext_colyseus_room_has_joined(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret) {
+    (void)p_method_userdata;
+    (void)p_args; // no arguments
+    
+    ColyseusRoomWrapper* wrapper = (ColyseusRoomWrapper*)p_instance;
+    if (wrapper && wrapper->native_room && r_ret) {
+        bool has_joined = colyseus_room_has_joined(wrapper->native_room);
+        // For bool, we cast the result directly to the pointer location
+        *(GDExtensionBool*)r_ret = has_joined ? 1 : 0;
+    }
+}

--- a/platforms/godot/src/godot_colyseus.h
+++ b/platforms/godot/src/godot_colyseus.h
@@ -33,6 +33,20 @@ typedef struct {
     uint8_t data[VARIANT_SIZE];
 } Variant;
 
+// Enums.
+typedef enum
+{
+    PROPERTY_HINT_NONE = 0,
+} PropertyHint;
+
+typedef enum
+{
+    PROPERTY_USAGE_NONE = 0,
+    PROPERTY_USAGE_STORAGE = 2,
+    PROPERTY_USAGE_EDITOR = 4,
+    PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR,
+} PropertyUsageFlags;
+
 // Forward declarations
 typedef struct ColyseusClient ColyseusClient;
 typedef struct ColyseusRoom ColyseusRoom;

--- a/platforms/godot/src/godot_colyseus.h
+++ b/platforms/godot/src/godot_colyseus.h
@@ -1,0 +1,108 @@
+#ifndef gdext_colyseus_H
+#define gdext_colyseus_H
+
+#include <gdextension_interface.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <colyseus/client.h>
+
+#ifdef REAL_T_IS_DOUBLE
+#define VARIANT_SIZE 40
+#else
+#define VARIANT_SIZE 24
+#endif
+
+#ifdef BUILD_32
+#define STRING_NAME_SIZE 4
+#define STRING_SIZE 4
+#else
+#define STRING_NAME_SIZE 8
+#define STRING_SIZE 8
+#endif
+
+// Opaque types
+typedef struct {
+    uint8_t data[STRING_NAME_SIZE]; 
+} StringName;
+
+typedef struct {
+    uint8_t data[STRING_SIZE]; 
+} String;
+
+typedef struct {
+    uint8_t data[VARIANT_SIZE];
+} Variant;
+
+// Forward declarations
+typedef struct ColyseusClient ColyseusClient;
+typedef struct ColyseusRoom ColyseusRoom;
+
+// Constructors struct
+struct Constructors
+{
+    GDExtensionInterfaceStringNameNewWithLatin1Chars string_name_new_with_latin1_chars;
+    GDExtensionInterfaceStringNewWithUtf8Chars string_new_with_utf8_chars;
+    GDExtensionVariantFromTypeConstructorFunc variant_from_string_constructor;
+    GDExtensionVariantFromTypeConstructorFunc variant_from_bool_constructor;
+    GDExtensionTypeFromVariantConstructorFunc string_from_variant_constructor;
+};
+
+// Destructors struct
+struct Destructors
+{
+    GDExtensionPtrDestructor string_name_destructor;
+    GDExtensionPtrDestructor string_destructor;
+    GDExtensionInterfaceVariantDestroy variant_destroy;
+};
+
+// Global instances (defined in register_types.c)
+extern struct Constructors constructors;
+extern struct Destructors destructors;
+
+// GDExtension interface struct - holds function pointers
+typedef struct {
+    GDExtensionInterfaceClassdbRegisterExtensionClass2 classdb_register_extension_class2;
+    GDExtensionInterfaceClassdbRegisterExtensionClassMethod classdb_register_extension_class_method;
+    GDExtensionInterfaceClassdbRegisterExtensionClassSignal classdb_register_extension_class_signal;
+    GDExtensionInterfaceClassdbConstructObject classdb_construct_object;
+    GDExtensionInterfaceObjectSetInstance object_set_instance;
+    GDExtensionInterfaceObjectSetInstanceBinding object_set_instance_binding;
+    GDExtensionInterfaceMemAlloc mem_alloc;
+    GDExtensionInterfaceMemFree mem_free;
+    GDExtensionInterfaceVariantGetPtrDestructor variant_get_ptr_destructor;
+    GDExtensionInterfaceStringNewWithUtf8CharsAndLen string_new_with_utf8_chars_and_len;
+} GDExtensionInterface;
+
+// GDExtension interface globals
+extern GDExtensionInterface api;
+extern GDExtensionClassLibraryPtr library;
+
+// ColyseusClientWrapper type
+typedef struct ColyseusClientWrapper {
+    colyseus_client_t* native_client;
+} ColyseusClientWrapper;
+
+// ColyseusClient methods
+GDExtensionObjectPtr gdext_colyseus_client_constructor(void* p_class_userdata);
+void gdext_colyseus_client_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
+void gdext_colyseus_client_connect_to(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+
+// Simple getter (reference implementation style)
+const char* gdext_colyseus_client_get_endpoint(const ColyseusClientWrapper* self);
+
+// GDExtension wrapper for the getter
+void gdext_colyseus_client_get_endpoint_wrapper(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+
+// ColyseusRoom methods
+GDExtensionObjectPtr gdext_colyseus_room_constructor(void* p_class_userdata);
+void gdext_colyseus_room_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
+void gdext_colyseus_room_send_message(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_room_send_message_int(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_room_leave(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_room_get_id(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_room_get_session_id(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_room_get_name(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_room_has_joined(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+
+#endif // gdext_colyseus_H
+

--- a/platforms/godot/src/godot_colyseus.h
+++ b/platforms/godot/src/godot_colyseus.h
@@ -58,6 +58,7 @@ struct Constructors
     GDExtensionInterfaceStringNewWithUtf8Chars string_new_with_utf8_chars;
     GDExtensionVariantFromTypeConstructorFunc variant_from_string_constructor;
     GDExtensionVariantFromTypeConstructorFunc variant_from_bool_constructor;
+    GDExtensionVariantFromTypeConstructorFunc variant_from_object_constructor;
     GDExtensionTypeFromVariantConstructorFunc string_from_variant_constructor;
 };
 
@@ -81,10 +82,12 @@ typedef struct {
     GDExtensionInterfaceClassdbConstructObject classdb_construct_object;
     GDExtensionInterfaceObjectSetInstance object_set_instance;
     GDExtensionInterfaceObjectSetInstanceBinding object_set_instance_binding;
+    GDExtensionInterfaceObjectGetInstanceBinding object_get_instance_binding;
     GDExtensionInterfaceMemAlloc mem_alloc;
     GDExtensionInterfaceMemFree mem_free;
     GDExtensionInterfaceVariantGetPtrDestructor variant_get_ptr_destructor;
     GDExtensionInterfaceStringNewWithUtf8CharsAndLen string_new_with_utf8_chars_and_len;
+    GDExtensionInterfaceStringToUtf8Chars string_to_utf8_chars;
 } GDExtensionInterface;
 
 // GDExtension interface globals
@@ -96,10 +99,20 @@ typedef struct ColyseusClientWrapper {
     colyseus_client_t* native_client;
 } ColyseusClientWrapper;
 
+// ColyseusRoomWrapper type (forward declaration)
+typedef struct {
+    colyseus_room_t* native_room;
+    GDExtensionObjectPtr godot_object;
+} ColyseusRoomWrapper;
+
 // ColyseusClient methods
 GDExtensionObjectPtr gdext_colyseus_client_constructor(void* p_class_userdata);
 void gdext_colyseus_client_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
+void gdext_colyseus_client_reference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
+void gdext_colyseus_client_unreference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
 void gdext_colyseus_client_connect_to(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
+void gdext_colyseus_client_join_or_create(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr* p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError* r_error);
+void gdext_colyseus_client_join_or_create_ptrcall(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
 
 // Simple getter (reference implementation style)
 const char* gdext_colyseus_client_get_endpoint(const ColyseusClientWrapper* self);
@@ -110,6 +123,8 @@ void gdext_colyseus_client_get_endpoint_wrapper(void* p_method_userdata, GDExten
 // ColyseusRoom methods
 GDExtensionObjectPtr gdext_colyseus_room_constructor(void* p_class_userdata);
 void gdext_colyseus_room_destructor(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
+void gdext_colyseus_room_reference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
+void gdext_colyseus_room_unreference(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
 void gdext_colyseus_room_send_message(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
 void gdext_colyseus_room_send_message_int(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);
 void gdext_colyseus_room_leave(void* p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr* p_args, GDExtensionTypePtr r_ret);

--- a/platforms/godot/src/register_types.c
+++ b/platforms/godot/src/register_types.c
@@ -1,0 +1,560 @@
+#include "godot_colyseus.h"
+#include <gdextension_interface.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef GDE_EXPORT
+#ifdef _WIN32
+#define GDE_EXPORT __declspec(dllexport)
+#else
+#define GDE_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+
+// Global GDExtension interface and library
+GDExtensionInterface api = {0};
+GDExtensionClassLibraryPtr class_library = NULL;
+
+// Global constructors and destructors
+struct Constructors constructors = {0};
+struct Destructors destructors = {0};
+
+// String name cache
+StringName string_name_joined;
+StringName string_name_state_changed;
+StringName string_name_message_received;
+StringName string_name_error;
+StringName string_name_left;
+
+static void initialize_string_names(void) {
+    // Create string names for signals using C strings directly
+    constructors.string_name_new_with_latin1_chars(&string_name_joined, "joined", false);
+    constructors.string_name_new_with_latin1_chars(&string_name_state_changed, "state_changed", false);
+    constructors.string_name_new_with_latin1_chars(&string_name_message_received, "message_received", false);
+    constructors.string_name_new_with_latin1_chars(&string_name_error, "error", false);
+    constructors.string_name_new_with_latin1_chars(&string_name_left, "left", false);
+}
+
+// Helper function to create property info
+static GDExtensionPropertyInfo make_property(GDExtensionVariantType type, const char *name) {
+    StringName *prop_name = NULL;
+    if (name != NULL) {
+        prop_name = malloc(sizeof(StringName));
+        constructors.string_name_new_with_latin1_chars(prop_name, name, false);
+    }
+    
+    GDExtensionPropertyInfo info = {
+        .type = type,
+        .name = prop_name,
+        .class_name = NULL,
+        .hint = 0,
+        .hint_string = NULL,
+        .usage = 6 // PROPERTY_USAGE_DEFAULT
+    };
+    return info;
+}
+
+// Helper function to destruct property info
+void destruct_property(GDExtensionPropertyInfo *info)
+{
+    destructors.string_name_destructor(info->name);
+    destructors.string_destructor(info->hint_string);
+    destructors.string_name_destructor(info->class_name);
+    api.mem_free(info->name);
+    api.mem_free(info->hint_string);
+    api.mem_free(info->class_name);
+}
+
+// Generic call/ptrcall implementations
+
+// 0 arguments, no return
+static void call_0_args_no_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstVariantPtr *, GDExtensionInt, GDExtensionVariantPtr, GDExtensionCallError *) = method_userdata;
+    function(method_userdata, p_instance, p_args, p_argument_count, r_return, r_error);
+}
+
+static void ptrcall_0_args_no_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstTypePtr *, GDExtensionTypePtr) = method_userdata;
+    function(method_userdata, p_instance, p_args, r_ret);
+}
+
+// 0 arguments, with return
+static void call_0_args_with_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstVariantPtr *, GDExtensionInt, GDExtensionVariantPtr, GDExtensionCallError *) = method_userdata;
+    function(method_userdata, p_instance, p_args, p_argument_count, r_return, r_error);
+}
+
+static void ptrcall_0_args_with_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstTypePtr *, GDExtensionTypePtr) = method_userdata;
+    function(method_userdata, p_instance, p_args, r_ret);
+}
+
+// 1 argument, no return
+static void call_1_arg_no_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstVariantPtr *, GDExtensionInt, GDExtensionVariantPtr, GDExtensionCallError *) = method_userdata;
+    function(method_userdata, p_instance, p_args, p_argument_count, r_return, r_error);
+}
+
+static void ptrcall_1_arg_no_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstTypePtr *, GDExtensionTypePtr) = method_userdata;
+    function(method_userdata, p_instance, p_args, r_ret);
+}
+
+// 2 arguments, no return
+static void call_2_args_no_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstVariantPtr *, GDExtensionInt, GDExtensionVariantPtr, GDExtensionCallError *) = method_userdata;
+    function(method_userdata, p_instance, p_args, p_argument_count, r_return, r_error);
+}
+
+static void ptrcall_2_args_no_ret(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret)
+{
+    void (*function)(void *, GDExtensionClassInstancePtr, const GDExtensionConstTypePtr *, GDExtensionTypePtr) = method_userdata;
+    function(method_userdata, p_instance, p_args, r_ret);
+}
+
+// Generic method binding: 0 arguments, no return
+static void bind_method_0_no_ret(
+    const char *class_name,
+    const char *method_name,
+    void *function)
+{
+    StringName method_name_string;
+    constructors.string_name_new_with_latin1_chars(&method_name_string, method_name, false);
+
+    GDExtensionClassMethodCall call_func = call_0_args_no_ret;
+    GDExtensionClassMethodPtrCall ptrcall_func = ptrcall_0_args_no_ret;
+
+    GDExtensionClassMethodInfo method_info = {
+        .name = &method_name_string,
+        .method_userdata = function,
+        .call_func = call_func,
+        .ptrcall_func = ptrcall_func,
+        .method_flags = GDEXTENSION_METHOD_FLAGS_DEFAULT,
+        .has_return_value = false,
+        .argument_count = 0,
+    };
+
+    StringName class_name_string;
+    constructors.string_name_new_with_latin1_chars(&class_name_string, class_name, false);
+
+    api.classdb_register_extension_class_method(class_library, &class_name_string, &method_info);
+
+    // Destruct things
+    destructors.string_name_destructor(&method_name_string);
+    destructors.string_name_destructor(&class_name_string);
+}
+
+// Generic method binding: 0 arguments, with return
+static void bind_method_0_with_ret(
+    const char *class_name,
+    const char *method_name,
+    void *function,
+    GDExtensionVariantType return_type)
+{
+    StringName method_name_string;
+    constructors.string_name_new_with_latin1_chars(&method_name_string, method_name, false);
+
+    GDExtensionClassMethodCall call_func = call_0_args_with_ret;
+    GDExtensionClassMethodPtrCall ptrcall_func = ptrcall_0_args_with_ret;
+
+    GDExtensionPropertyInfo return_info = make_property(return_type, "");
+
+    GDExtensionClassMethodInfo method_info = {
+        .name = &method_name_string,
+        .method_userdata = function,
+        .call_func = call_func,
+        .ptrcall_func = ptrcall_func,
+        .method_flags = GDEXTENSION_METHOD_FLAGS_DEFAULT,
+        .has_return_value = true,
+        .return_value_info = &return_info,
+        .return_value_metadata = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+        .argument_count = 0,
+    };
+
+    StringName class_name_string;
+    constructors.string_name_new_with_latin1_chars(&class_name_string, class_name, false);
+
+    api.classdb_register_extension_class_method(class_library, &class_name_string, &method_info);
+
+    // Destruct things.
+    destructors.string_name_destructor(&method_name_string);
+    destructors.string_name_destructor(&class_name_string);
+    destruct_property(&return_info);
+}
+
+// Generic method binding: 1 argument, no return
+static void bind_method_1_no_ret(
+    const char *class_name,
+    const char *method_name,
+    void *function,
+    const char *arg1_name,
+    GDExtensionVariantType arg1_type)
+{
+    StringName method_name_string;
+    constructors.string_name_new_with_latin1_chars(&method_name_string, method_name, false);
+
+    GDExtensionPropertyInfo args_info[] = {
+        make_property(arg1_type, arg1_name),
+    };
+    GDExtensionClassMethodArgumentMetadata args_metadata[] = {
+        GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+    };
+
+    GDExtensionClassMethodInfo method_info = {
+        .name = &method_name_string,
+        .method_userdata = function,
+        .call_func = call_1_arg_no_ret,
+        .ptrcall_func = ptrcall_1_arg_no_ret,
+        .method_flags = GDEXTENSION_METHOD_FLAG_NORMAL,
+        .has_return_value = false,
+        .return_value_info = NULL,
+        .return_value_metadata = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+        .argument_count = 1,
+        .arguments_info = args_info,
+        .arguments_metadata = args_metadata,
+        .default_argument_count = 0,
+        .default_arguments = NULL
+    };
+
+    StringName class_name_string;
+    constructors.string_name_new_with_latin1_chars(&class_name_string, class_name, false);
+
+    api.classdb_register_extension_class_method(class_library, &class_name_string, &method_info);
+
+    destructors.string_name_destructor(&method_name_string);
+    destructors.string_name_destructor(&class_name_string);
+    destruct_property(&args_info[0]);
+}
+
+// Generic method binding: 2 arguments, no return
+static void bind_method_2_no_ret(
+    const char *class_name,
+    const char *method_name,
+    void *function,
+    const char *arg1_name,
+    GDExtensionVariantType arg1_type,
+    const char *arg2_name,
+    GDExtensionVariantType arg2_type)
+{
+    StringName method_name_string;
+    constructors.string_name_new_with_latin1_chars(&method_name_string, method_name, false);
+
+    GDExtensionPropertyInfo args_info[] = {
+        make_property(arg1_type, arg1_name),
+        make_property(arg2_type, arg2_name),
+    };
+    GDExtensionClassMethodArgumentMetadata args_metadata[] = {
+        GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+        GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+    };
+
+    GDExtensionClassMethodInfo method_info = {
+        .name = &method_name_string,
+        .method_userdata = function,
+        .call_func = call_2_args_no_ret,
+        .ptrcall_func = ptrcall_2_args_no_ret,
+        .method_flags = GDEXTENSION_METHOD_FLAG_NORMAL,
+        .has_return_value = false,
+        .return_value_info = NULL,
+        .return_value_metadata = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE,
+        .argument_count = 2,
+        .arguments_info = args_info,
+        .arguments_metadata = args_metadata,
+        .default_argument_count = 0,
+        .default_arguments = NULL
+    };
+
+    StringName class_name_string;
+    constructors.string_name_new_with_latin1_chars(&class_name_string, class_name, false);
+
+    api.classdb_register_extension_class_method(class_library, &class_name_string, &method_info);
+
+    destructors.string_name_destructor(&method_name_string);
+    destructors.string_name_destructor(&class_name_string);
+    destruct_property(&args_info[0]);
+    destruct_property(&args_info[1]);
+}
+
+static void register_colyseus_client(void) {
+    printf("[ColyseusClient] Starting registration\n");
+    fflush(stdout);
+
+    GDExtensionClassCreationInfo2 class_info = {
+        .is_virtual = false,
+        .is_abstract = false,
+        .is_exposed = true,
+        .set_func = NULL,
+        .get_func = NULL,
+        .get_property_list_func = NULL,
+        .free_property_list_func = NULL,
+        .property_can_revert_func = NULL,
+        .property_get_revert_func = NULL,
+        .validate_property_func = NULL,
+        .notification_func = NULL,
+        .to_string_func = NULL,
+        .reference_func = NULL,
+        .unreference_func = NULL,
+        .create_instance_func = gdext_colyseus_client_constructor,
+        .free_instance_func = gdext_colyseus_client_destructor,
+        .recreate_instance_func = NULL,
+        .get_virtual_func = NULL,
+        .get_virtual_call_data_func = NULL,
+        .call_virtual_with_data_func = NULL,
+        .get_rid_func = NULL,
+        .class_userdata = NULL,
+    };
+
+    printf("[ColyseusClient] Allocating StringNames\n");
+    fflush(stdout);
+
+    // Initialize StringNames
+    StringName class_name;
+    StringName parent_class_name;
+
+    printf("[ColyseusClient] Creating class_name StringName\n");
+    fflush(stdout);
+    constructors.string_name_new_with_latin1_chars(&class_name, "ColyseusClient", false);
+
+    printf("[ColyseusClient] Creating parent_class_name StringName\n");
+    fflush(stdout);
+    constructors.string_name_new_with_latin1_chars(&parent_class_name, "RefCounted", false);
+
+    printf("[ColyseusClient] Registering class\n");
+    fflush(stdout);
+    api.classdb_register_extension_class2(class_library, &class_name, &parent_class_name, &class_info);
+    printf("[ColyseusClient] Class registered successfully\n");
+    fflush(stdout);
+
+    // Register methods using generic helpers
+    printf("[ColyseusClient] Registering connect_to method\n");
+    fflush(stdout);
+
+    // bind_method_1_no_ret(
+    //     "ColyseusClient",
+    //     "connect_to",
+    //     gdext_colyseus_client_connect_to,
+    //     "endpoint",
+    //     GDEXTENSION_VARIANT_TYPE_STRING
+    // );
+
+    printf("[ColyseusClient] connect_to method registered successfully\n");
+    fflush(stdout);
+
+    printf("[ColyseusClient] Registering get_endpoint method\n");
+    fflush(stdout);
+
+    bind_method_0_with_ret(
+        "ColyseusClient",
+        "get_endpoint",
+        gdext_colyseus_client_get_endpoint,
+        GDEXTENSION_VARIANT_TYPE_STRING
+    );
+
+    printf("[ColyseusClient] get_endpoint method registered successfully\n");
+    fflush(stdout);
+
+    printf("[ColyseusClient] Registration complete\n");
+    fflush(stdout);
+}
+
+static void register_colyseus_room(void) {
+    GDExtensionClassCreationInfo2 class_info = {
+        .is_virtual = false,
+        .is_abstract = false,
+        .is_exposed = true,
+        .set_func = NULL,
+        .get_func = NULL,
+        .get_property_list_func = NULL,
+        .free_property_list_func = NULL,
+        .property_can_revert_func = NULL,
+        .property_get_revert_func = NULL,
+        .validate_property_func = NULL,
+        .notification_func = NULL,
+        .to_string_func = NULL,
+        .reference_func = NULL,
+        .unreference_func = NULL,
+        .create_instance_func = gdext_colyseus_room_constructor,
+        .free_instance_func = gdext_colyseus_room_destructor,
+        .recreate_instance_func = NULL,
+        .get_virtual_func = NULL,
+        .get_virtual_call_data_func = NULL,
+        .call_virtual_with_data_func = NULL,
+        .get_rid_func = NULL,
+        .class_userdata = NULL
+    };
+
+    // Initialize StringNames
+    StringName class_name;
+    StringName parent_class_name;
+
+    constructors.string_name_new_with_latin1_chars(&class_name, "ColyseusRoom", false);
+    constructors.string_name_new_with_latin1_chars(&parent_class_name, "RefCounted", false);
+
+    api.classdb_register_extension_class2(class_library, &class_name, &parent_class_name, &class_info);
+
+    // Register signals
+    GDExtensionPropertyInfo signal_params[2];
+
+    // joined signal
+    api.classdb_register_extension_class_signal(class_library, &class_name, &string_name_joined, NULL, 0);
+
+    // state_changed signal
+    api.classdb_register_extension_class_signal(class_library, &class_name, &string_name_state_changed, NULL, 0);
+
+    // message_received signal (data: PackedByteArray)
+    memset(signal_params, 0, sizeof(signal_params));
+    signal_params[0].type = GDEXTENSION_VARIANT_TYPE_PACKED_BYTE_ARRAY;
+    StringName signal_param_data;
+    constructors.string_name_new_with_latin1_chars(&signal_param_data, "data", false);
+    signal_params[0].name = &signal_param_data;
+    api.classdb_register_extension_class_signal(class_library, &class_name, &string_name_message_received, signal_params, 1);
+
+    // error signal (code: int, message: String)
+    memset(signal_params, 0, sizeof(signal_params));
+    signal_params[0].type = GDEXTENSION_VARIANT_TYPE_INT;
+    StringName signal_param_code;
+    constructors.string_name_new_with_latin1_chars(&signal_param_code, "code", false);
+    signal_params[0].name = &signal_param_code;
+    signal_params[1].type = GDEXTENSION_VARIANT_TYPE_STRING;
+    StringName signal_param_message;
+    constructors.string_name_new_with_latin1_chars(&signal_param_message, "message", false);
+    signal_params[1].name = &signal_param_message;
+    api.classdb_register_extension_class_signal(class_library, &class_name, &string_name_error, signal_params, 2);
+
+    // left signal (code: int, reason: String)
+    api.classdb_register_extension_class_signal(class_library, &class_name, &string_name_left, signal_params, 2);
+
+    // Register methods using generic helpers
+    
+    bind_method_2_no_ret(
+        "ColyseusRoom",
+        "send_message",
+        gdext_colyseus_room_send_message,
+        "type",
+        GDEXTENSION_VARIANT_TYPE_STRING,
+        "data",
+        GDEXTENSION_VARIANT_TYPE_PACKED_BYTE_ARRAY
+    );
+
+    bind_method_2_no_ret(
+        "ColyseusRoom",
+        "send_message_int",
+        gdext_colyseus_room_send_message_int,
+        "type",
+        GDEXTENSION_VARIANT_TYPE_INT,
+        "data",
+        GDEXTENSION_VARIANT_TYPE_PACKED_BYTE_ARRAY
+    );
+
+    bind_method_0_no_ret(
+        "ColyseusRoom",
+        "leave",
+        gdext_colyseus_room_leave
+    );
+
+    bind_method_0_with_ret(
+        "ColyseusRoom",
+        "get_id",
+        gdext_colyseus_room_get_id,
+        GDEXTENSION_VARIANT_TYPE_STRING
+    );
+
+    bind_method_0_with_ret(
+        "ColyseusRoom",
+        "get_session_id",
+        gdext_colyseus_room_get_session_id,
+        GDEXTENSION_VARIANT_TYPE_STRING
+    );
+
+    bind_method_0_with_ret(
+        "ColyseusRoom",
+        "get_name",
+        gdext_colyseus_room_get_name,
+        GDEXTENSION_VARIANT_TYPE_STRING
+    );
+
+    bind_method_0_with_ret(
+        "ColyseusRoom",
+        "has_joined",
+        gdext_colyseus_room_has_joined,
+        GDEXTENSION_VARIANT_TYPE_BOOL
+    );
+}
+
+static void colyseus_initialize(void *userdata, GDExtensionInitializationLevel p_level) {
+    (void)userdata;
+    if (p_level != GDEXTENSION_INITIALIZATION_SCENE) {
+        return;
+    }
+    
+    initialize_string_names();
+    register_colyseus_client();
+    register_colyseus_room();
+}
+
+static void colyseus_deinitialize(void *userdata, GDExtensionInitializationLevel p_level) {
+    (void)userdata;
+    if (p_level != GDEXTENSION_INITIALIZATION_SCENE) {
+        return;
+    }
+    
+    // Cleanup string names (no need to free since they're stack-allocated)
+    destructors.string_name_destructor(&string_name_joined);
+    destructors.string_name_destructor(&string_name_state_changed);
+    destructors.string_name_destructor(&string_name_message_received);
+    destructors.string_name_destructor(&string_name_error);
+    destructors.string_name_destructor(&string_name_left);
+}
+
+GDExtensionBool GDE_EXPORT colyseus_sdk_init(
+    GDExtensionInterfaceGetProcAddress p_get_proc_address,
+    GDExtensionClassLibraryPtr p_library,
+    GDExtensionInitialization *r_initialization
+) {
+    class_library = p_library;
+
+    // API functions.
+    api.classdb_register_extension_class2 = (GDExtensionInterfaceClassdbRegisterExtensionClass2)p_get_proc_address("classdb_register_extension_class2");
+    api.classdb_register_extension_class_method = (GDExtensionInterfaceClassdbRegisterExtensionClassMethod)p_get_proc_address("classdb_register_extension_class_method");
+    api.classdb_register_extension_class_signal = (GDExtensionInterfaceClassdbRegisterExtensionClassSignal)p_get_proc_address("classdb_register_extension_class_signal");
+    api.classdb_construct_object = (GDExtensionInterfaceClassdbConstructObject)p_get_proc_address("classdb_construct_object");
+    api.object_set_instance = (GDExtensionInterfaceObjectSetInstance)p_get_proc_address("object_set_instance");
+    api.object_set_instance_binding = (GDExtensionInterfaceObjectSetInstanceBinding)p_get_proc_address("object_set_instance_binding");
+    api.mem_alloc = (GDExtensionInterfaceMemAlloc)p_get_proc_address("mem_alloc");
+    api.mem_free = (GDExtensionInterfaceMemFree)p_get_proc_address("mem_free");
+    api.variant_get_ptr_destructor = (GDExtensionInterfaceVariantGetPtrDestructor)p_get_proc_address("variant_get_ptr_destructor");
+    api.string_new_with_utf8_chars_and_len = (GDExtensionInterfaceStringNewWithUtf8CharsAndLen)p_get_proc_address("string_new_with_utf8_chars_and_len");
+
+    // Get variant from type constructor function
+    GDExtensionInterfaceGetVariantFromTypeConstructor get_variant_from_type_constructor = 
+        (GDExtensionInterfaceGetVariantFromTypeConstructor)p_get_proc_address("get_variant_from_type_constructor");
+    GDExtensionInterfaceGetVariantToTypeConstructor get_variant_to_type_constructor = 
+        (GDExtensionInterfaceGetVariantToTypeConstructor)p_get_proc_address("get_variant_to_type_constructor");
+
+    // Constructors.
+    constructors.string_name_new_with_latin1_chars = (GDExtensionInterfaceStringNameNewWithLatin1Chars)p_get_proc_address("string_name_new_with_latin1_chars");
+    constructors.string_new_with_utf8_chars = (GDExtensionInterfaceStringNewWithUtf8Chars)p_get_proc_address("string_new_with_utf8_chars");
+    constructors.variant_from_string_constructor = get_variant_from_type_constructor(GDEXTENSION_VARIANT_TYPE_STRING);
+    constructors.variant_from_bool_constructor = get_variant_from_type_constructor(GDEXTENSION_VARIANT_TYPE_BOOL);
+    constructors.string_from_variant_constructor = get_variant_to_type_constructor(GDEXTENSION_VARIANT_TYPE_STRING);
+
+    // Destructors.
+    destructors.string_name_destructor = api.variant_get_ptr_destructor(GDEXTENSION_VARIANT_TYPE_STRING_NAME);
+    destructors.string_destructor = api.variant_get_ptr_destructor(GDEXTENSION_VARIANT_TYPE_STRING);
+    destructors.variant_destroy = (GDExtensionInterfaceVariantDestroy)p_get_proc_address("variant_destroy");
+
+    r_initialization->initialize = colyseus_initialize;
+    r_initialization->deinitialize = colyseus_deinitialize;
+    r_initialization->minimum_initialization_level = GDEXTENSION_INITIALIZATION_SCENE;
+
+    return 1;
+}
+


### PR DESCRIPTION
WIP barebones `platforms/godot` structure to experiment with GDExtension for Godot 4+. 

Following this user guide: https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_c_example.html

The extension is currently **not loading** in Godot. It's SEGFAULTING with the following:

```
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.5.1.stable.official (f62fdbde15035c5576dad93e586201f4d41ef0cb)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] 1   libsystem_platform.dylib            0x000000018c5e2a24 _sigtramp + 56
[2] GDExtensionEditorHelp::load_xml_buffer(unsigned char const*, int)
[3] GDExtensionEditorHelp::load_xml_buffer(unsigned char const*, int)
[4] GDExtension::_register_extension_class_method(void*, void const*, GDExtensionClassMethodInfo const*) (in Godot) + 448
[5] 5   libcolyseus_godot.macos.debug.dylib 0x00000001125298b4 bind_method_0_with_ret + 344
[6] 6   libcolyseus_godot.macos.debug.dylib 0x0000000112528f98 register_colyseus_client + 416
[7] 7   libcolyseus_godot.macos.debug.dylib 0x0000000112528c84 colyseus_initialize + 48
[8] GDExtensionManager::initialize_extensions(GDExtension::InitializationLevel) (in Godot) + 92
[9] Main::setup2(bool) (in Godot) + 17884
[10] Main::setup(char const*, int, char**, bool) (in Godot) + 96336
[11] OS_MacOS_NSApp::start_main() (in Godot) + 52
```