### PR TITLE
Windows build

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
+          vcpkg install curl:x64-windows
           git submodule update --init --recursive
 
       - name: Run tests

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          vcpkg install curl:x64-windows
+          git clone https://github.com/microsoft/vcpkg.git ..\vcpkg
+          ..\vcpkg\bootstrap-vcpkg.bat
+          ..\vcpkg\vcpkg install curl:x64-windows
           git submodule update --init --recursive
 
       - name: Run tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third_party/wslay"]
 	path = third_party/wslay
 	url = https://github.com/tatsuhiro-t/wslay.git
+[submodule "third_party/curl"]
+	path = third_party/curl
+	url = https://github.com/curl/curl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "third_party/wslay"]
 	path = third_party/wslay
 	url = https://github.com/tatsuhiro-t/wslay.git
-[submodule "third_party/curl"]
-	path = third_party/curl
-	url = https://github.com/curl/curl.git

--- a/BUILD_WITH_ZIG.md
+++ b/BUILD_WITH_ZIG.md
@@ -103,10 +103,12 @@ zig build -Dexamples=false
 
 One of Zig's best features is easy cross-compilation!
 
-**Build for Windows from macOS/Linux:**
+**Build for Windows (MinGW) from macOS/Linux:**
 ```bash
-zig build -Dtarget=x86_64-windows
+zig build -Dtarget=x86_64-windows-gnu
 ```
+
+> **Note:** The build system is configured to use MinGW (GNU ABI) on Windows. See [WINDOWS_COMPILATION.md](WINDOWS_COMPILATION.md) for detailed Windows build instructions.
 
 **Build for Linux from macOS:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ native-sdk/
 ## 📖 Documentation
 
 - [Building with Zig](BUILD_WITH_ZIG.md) - Comprehensive Zig build guide
+- [Windows Compilation](WINDOWS_COMPILATION.md) - Building on Windows with MinGW
 - [Colyseus Documentation](https://docs.colyseus.io/) - Server documentation
 
 ## ⚠️ Status

--- a/build.zig
+++ b/build.zig
@@ -173,7 +173,11 @@ pub fn build(b: *std.Build) void {
         colyseus.linkFramework("CoreFoundation");
         colyseus.linkFramework("Security");
     } else if (target.result.os.tag == .windows) {
-        const vcpkg_root = "../vcpkg/installed/x64-windows";
+        // Allow vcpkg root to be overridden via environment variable
+        const vcpkg_root_env = std.process.getEnvVarOwned(b.allocator, "VCPKG_ROOT") catch null;
+        const vcpkg_root = vcpkg_root_env orelse "../vcpkg/installed/x64-windows";
+        defer if (vcpkg_root_env) |env| b.allocator.free(env);
+
         colyseus.addIncludePath(b.path(vcpkg_root ++ "/include"));
 
         // Construct the path to libcurl.lib

--- a/build.zig
+++ b/build.zig
@@ -178,10 +178,11 @@ pub fn build(b: *std.Build) void {
         const vcpkg_root = vcpkg_root_env orelse "../vcpkg/installed/x64-windows";
         defer if (vcpkg_root_env) |env| b.allocator.free(env);
 
-        colyseus.addIncludePath(b.path(vcpkg_root ++ "/include"));
+        const vcpkg_include_path = b.fmt("{s}/include", .{vcpkg_root});
+        colyseus.addIncludePath(b.path(vcpkg_include_path));
 
         // Construct the path to libcurl.lib
-        const libcurl_path = b.pathJoin(&.{ vcpkg_root, "lib", "libcurl.lib" });
+        const libcurl_path = b.fmt("{s}/lib/libcurl.lib", .{vcpkg_root});
         colyseus.addObjectFile(b.path(libcurl_path));
         colyseus.linkSystemLibrary("ws2_32");
         colyseus.linkSystemLibrary("crypt32");

--- a/build.zig
+++ b/build.zig
@@ -178,12 +178,15 @@ pub fn build(b: *std.Build) void {
         const vcpkg_root = vcpkg_root_env orelse "../vcpkg/installed/x64-windows";
         defer if (vcpkg_root_env) |env| b.allocator.free(env);
 
+        // Add vcpkg include and lib paths
         const vcpkg_include_path = b.fmt("{s}/include", .{vcpkg_root});
-        colyseus.addIncludePath(b.path(vcpkg_include_path));
+        const vcpkg_lib_path = b.fmt("{s}/lib", .{vcpkg_root});
 
-        // Construct the path to libcurl.lib
-        const libcurl_path = b.fmt("{s}/lib/libcurl.lib", .{vcpkg_root});
-        colyseus.addObjectFile(b.path(libcurl_path));
+        colyseus.addIncludePath(.{ .cwd_relative = vcpkg_include_path });
+        colyseus.addLibraryPath(.{ .cwd_relative = vcpkg_lib_path });
+
+        // Link libcurl as a system library
+        colyseus.linkSystemLibrary("libcurl");
         colyseus.linkSystemLibrary("ws2_32");
         colyseus.linkSystemLibrary("crypt32");
     } else {

--- a/build.zig
+++ b/build.zig
@@ -8,8 +8,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Determine C standard based on platform
-    // Use gnu11 for Linux and Windows (MinGW), c11 for other platforms
-    const c_std = if (target.result.os.tag == .linux or target.result.os.tag == .windows) "-std=gnu11" else "-std=c11";
+    const c_std = if (target.result.os.tag == .linux) "-std=gnu11" else "-std=c11";
 
     // Build options
     const build_shared = b.option(bool, "shared", "Build shared library") orelse false;
@@ -22,24 +21,16 @@ pub fn build(b: *std.Build) void {
     // ========================================================================
 
     // Generate config.h for wslay based on target platform
-    const is_windows = target.result.os.tag == .windows;
-
-    // Create config header with platform-specific values
-    const wslay_config_h: *std.Build.Step.ConfigHeader = if (is_windows)
-        b.addConfigHeader(.{
-            .style = .blank,
-            .include_path = "config.h",
-        }, .{
-            .HAVE_WINSOCK2_H = 1,
-        })
-    else
-        b.addConfigHeader(.{
-            .style = .blank,
-            .include_path = "config.h",
-        }, .{
-            .HAVE_ARPA_INET_H = 1,
-            .HAVE_NETINET_IN_H = 1,
-        });
+    // For most common platforms (Unix-like systems)
+    const wslay_config_h = b.addConfigHeader(.{
+        .style = .blank,
+        .include_path = "config.h",
+    }, .{
+        .HAVE_ARPA_INET_H = 1, // Available on Unix-like systems
+        .HAVE_NETINET_IN_H = 1, // Available on Unix-like systems
+        // HAVE_WINSOCK2_H not defined on Unix
+        // WORDS_BIGENDIAN not defined (little-endian is most common)
+    });
 
     // Generate wslayver.h for wslay
     const wslay_version_h = b.addConfigHeader(.{


### PR DESCRIPTION
The `regex.h` is not available on Windows, so this PR also changes the `colyseus_parse_url` implementation to use the CURL module for URL parsing instead.