### PR TITLE
Fix memory leaks and buffer corruption in HTTP and WebSocket transport

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -36,8 +36,6 @@ jobs:
           echo "Version: ${{ steps.version-check.outputs.version }}"
 
   build-macos:
-    needs: check-version
-    if: needs.check-version.outputs.changed == 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -65,8 +63,6 @@ jobs:
           path: platforms/godot/addons/colyseus/bin/*.dylib
 
   build-ios:
-    needs: check-version
-    if: needs.check-version.outputs.changed == 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -344,8 +340,6 @@ jobs:
           path: platforms/godot/addons/colyseus/bin/*ios*.dylib
 
   build-linux:
-    needs: check-version
-    if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -373,8 +367,6 @@ jobs:
           path: platforms/godot/addons/colyseus/bin/*.so
 
   build-windows:
-    needs: check-version
-    if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -410,8 +402,6 @@ jobs:
           path: platforms/godot/addons/colyseus/bin/*.dll
 
   build-android:
-    needs: check-version
-    if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/include/colyseus/websocket_transport.h
+++ b/include/colyseus/websocket_transport.h
@@ -34,6 +34,7 @@ extern "C" {
         /* size_t fields (8 bytes on 64-bit) */
         size_t buffer_size;
         size_t buffer_offset;
+        size_t handshake_len;
 
         /* 4-byte fields */
         colyseus_ws_state_t state;

--- a/src/msgpack/msgpack_builder.zig
+++ b/src/msgpack/msgpack_builder.zig
@@ -231,7 +231,10 @@ fn getPayloadForEncoding(wrapper: *PayloadWrapper) ?Payload {
             if (wrapper.array_elements) |list| {
                 var arr_payload = Payload.arrPayload(list.items.len, allocator) catch return null;
                 for (list.items, 0..) |item, i| {
-                    arr_payload.setArrElement(i, item) catch return null;
+                    arr_payload.setArrElement(i, item) catch {
+                        arr_payload.free(allocator);
+                        return null;
+                    };
                 }
                 return arr_payload;
             }

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -16,6 +16,16 @@ const http = if (!is_emscripten) std.http else struct {
     };
 };
 
+const OwnedHeaders = struct {
+    headers: []const http.Header,
+    auth_value: ?[]u8, // only field allocated by Zig
+
+    fn deinit(self: *OwnedHeaders, alloc: Allocator) void {
+        if (self.auth_value) |v| alloc.free(v);
+        alloc.free(self.headers);
+    }
+};
+
 // Forward declarations for C types (avoiding @cImport to support iOS cross-compilation)
 // These match the definitions in colyseus/settings.h and uthash.h
 
@@ -234,8 +244,8 @@ fn httpRequestImpl(
     var response_writer: std.Io.Writer.Allocating = .init(allocator);
     defer response_writer.deinit();
 
-    const extra_headers = try buildHeaders(h);
-    defer allocator.free(extra_headers);
+    var owned_headers = try buildHeaders(h);
+    defer owned_headers.deinit(allocator);
 
     const body_slice = if (body_cstr != null) cStrToSlice(body_cstr) else null;
 
@@ -243,7 +253,7 @@ fn httpRequestImpl(
         .location = .{ .url = url },
         .method = method,
         .payload = body_slice,
-        .extra_headers = extra_headers,
+        .extra_headers = owned_headers.headers,
         .response_writer = &response_writer.writer,
     }) catch |err| {
         if (on_error) |callback| {
@@ -308,8 +318,9 @@ fn buildUrl(alloc: Allocator, base: []const u8, path: []const u8) ![]u8 {
     }
 }
 
-fn buildHeaders(http_client: *colyseus_http_t) ![]const http.Header {
+fn buildHeaders(http_client: *colyseus_http_t) !OwnedHeaders {
     var headers: std.ArrayListUnmanaged(http.Header) = .empty;
+    var auth_value: ?[]u8 = null;
 
     var header: ?*colyseus_header_t = http_client.settings.headers;
     while (header) |h| {
@@ -324,10 +335,14 @@ fn buildHeaders(http_client: *colyseus_http_t) ![]const http.Header {
     if (http_client.auth_token != null) {
         const token_slice = cStrToSlice(http_client.auth_token);
         if (token_slice) |tok| {
-            const auth_value = try std.fmt.allocPrint(allocator, "Bearer {s}", .{tok});
-            try headers.append(allocator, .{ .name = "Authorization", .value = auth_value });
+            auth_value = try std.fmt.allocPrint(allocator, "Bearer {s}", .{tok});
+            errdefer if (auth_value) |v| allocator.free(v); // leak-safe on append failure
+            try headers.append(allocator, .{ .name = "Authorization", .value = auth_value.? });
         }
     }
 
-    return headers.toOwnedSlice(allocator);
+    return OwnedHeaders{
+        .headers = try headers.toOwnedSlice(allocator),
+        .auth_value = auth_value,
+    };
 }

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -320,7 +320,10 @@ fn buildUrl(alloc: Allocator, base: []const u8, path: []const u8) ![]u8 {
 
 fn buildHeaders(http_client: *colyseus_http_t) !OwnedHeaders {
     var headers: std.ArrayListUnmanaged(http.Header) = .empty;
+    errdefer headers.deinit(allocator); // leak-safe on any failure
+
     var auth_value: ?[]u8 = null;
+    errdefer if (auth_value) |v| allocator.free(v); // leak-safe on any failure
 
     var header: ?*colyseus_header_t = http_client.settings.headers;
     while (header) |h| {
@@ -336,7 +339,6 @@ fn buildHeaders(http_client: *colyseus_http_t) !OwnedHeaders {
         const token_slice = cStrToSlice(http_client.auth_token);
         if (token_slice) |tok| {
             auth_value = try std.fmt.allocPrint(allocator, "Bearer {s}", .{tok});
-            errdefer if (auth_value) |v| allocator.free(v); // leak-safe on append failure
             try headers.append(allocator, .{ .name = "Authorization", .value = auth_value.? });
         }
     }

--- a/src/network/websocket_transport.c
+++ b/src/network/websocket_transport.c
@@ -123,6 +123,8 @@ static void ws_connect_impl(colyseus_transport_t* transport, const char* url) {
 
     if (!ws_connect_init(data)) {
         WS_LOG("Connect init failed");
+        free(data->url);
+        data->url = NULL;
         if (transport->events.on_error) {
             transport->events.on_error("Failed to initialize connection", transport->events.userdata);
         }

--- a/src/network/websocket_transport.c
+++ b/src/network/websocket_transport.c
@@ -495,8 +495,8 @@ static bool ws_http_handshake_init(colyseus_ws_transport_data_t* data) {
     memcpy(data->buffer, request, req_len);
     data->buffer_offset = 0;
 
-    /* Store length at end for sending */
-    *(size_t*)(data->buffer + data->buffer_size - sizeof(size_t)) = req_len;
+    /* Store length for sending */
+    data->handshake_len = req_len;
 
     sdsfree(request);
     return true;
@@ -506,7 +506,7 @@ static bool ws_http_handshake_init(colyseus_ws_transport_data_t* data) {
 /* (Due to length, showing key parts - full implementation follows same pattern as C++ version) */
 
 static bool ws_http_handshake_send(colyseus_ws_transport_data_t* data) {
-    size_t total_len = *(size_t*)(data->buffer + data->buffer_size - sizeof(size_t));
+    size_t total_len = data->handshake_len;
 
     while (data->buffer_offset < total_len) {
         int would_block = 0;


### PR DESCRIPTION
# src/network/http.zig
- Added OwnedHeaders struct to explicitly track Zig-allocated header memory
buildHeaders now returns OwnedHeaders instead of a raw slice, preventing auth_value ("Bearer <token>") from leaking on every request
- Added function-scope errdefer for both headers and auth_value to handle cleanup on partial failure
# src/network/websocket_transport.c
- Fixed data->url leak in ws_connect_impl when ws_connect_init fails
- Replaced buffer-end hack `*(size_t*)(data->buffer + data->buffer_size - sizeof(size_t))` with `data->handshake_len` field in the struct, eliminating potential buffer corruption when handshake request length approached buffer size

# Godot CI change
- Only use check versions for release, let the platform build for any manual checks.
- Job in action: https://github.com/colyseus/native-sdk/actions/runs/22317583607